### PR TITLE
Implement fast ZETA test

### DIFF
--- a/pylabianca/_numba.py
+++ b/pylabianca/_numba.py
@@ -56,6 +56,15 @@ def _monotonic_unique_counts(values):
     return uni, cnt
 
 
+@njit
+def _monotonic_find_first(values, find_val):
+    n_val = values.shape[0]
+    for idx in range(n_val):
+        if values[idx] == find_val:
+            return idx
+    return -1
+
+
 def numba_compare_times(spk, cell_idx1, cell_idx2, spk2=None):
     times1 = (spk.timestamps[cell_idx1] / spk.sfreq).astype('float64')
 
@@ -287,3 +296,27 @@ def concat_times(times, n_in_trial):
         idx = idx_end
 
     return time
+
+
+@njit
+def _select_spikes_numba(spikes, trials, tri_sel):
+    '''Assumes both trials and tri_sel are sorted.'''
+    tri_sel_idx = 0
+    current_tri = tri_sel[tri_sel_idx]
+    msk = np.zeros(len(trials), dtype='bool')
+    for idx, tri in enumerate(trials):
+        if tri < current_tri:
+            continue
+
+        if tri == current_tri:
+            msk[idx] = True
+        elif tri > current_tri:
+            too_low = True
+            while too_low:
+                tri_sel_idx += 1
+                current_tri = tri_sel[tri_sel_idx]
+                too_low = tri > current_tri
+            if tri == current_tri:
+                msk[idx] = True
+
+    return spikes[msk]

--- a/pylabianca/_numba.py
+++ b/pylabianca/_numba.py
@@ -1,9 +1,9 @@
 import numpy as np
-from numba import jit
+from numba import jit, njit
 from numba.extending import overload
 
 
-@jit(nopython=True)
+@njit
 def _compute_spike_rate_numba(spike_times, spike_trials, time_limits,
                               n_trials, winlen=0.25, step=0.05):
     half_win = winlen / 2
@@ -26,7 +26,7 @@ def _compute_spike_rate_numba(spike_times, spike_trials, time_limits,
     return times, frate
 
 
-@jit(nopython=True)
+@njit
 def _monotonic_unique_counts(values):
     n_val = len(values)
     if n_val == 0:
@@ -67,7 +67,7 @@ def numba_compare_times(spk, cell_idx1, cell_idx2, spk2=None):
     return res
 
 
-@jit(nopython=True)
+@njit
 def _numba_compare_times(times1, times2, distances):
     n_times1 = times1.shape[0]
     n_times2 = times2.shape[0]
@@ -87,7 +87,7 @@ def _numba_compare_times(times1, times2, distances):
     return distances
 
 
-@jit(nopython=True)
+@njit
 def _xcorr_hist_auto_numba(times, bins, batch_size=1_000):
     '''Compute auto-correlation histogram for a single cell.
 
@@ -125,7 +125,7 @@ def _xcorr_hist_auto_numba(times, bins, batch_size=1_000):
     return counts
 
 
-@jit(nopython=True)
+@njit
 def _xcorr_hist_cross_numba(times, times2, bins, batch_size=1_000):
     '''Compute cross-correlation histogram for a single cell.
 
@@ -179,7 +179,7 @@ def _xcorr_hist_cross_numba(times, times2, bins, batch_size=1_000):
     return counts
 
 
-@jit(nopython=True)
+@njit
 def compute_bin(x, bin_edges):
     '''Copied from https://numba.pydata.org/numba-examples/examples/density_estimation/histogram/results.html'''
     # assuming uniform bins for now
@@ -199,7 +199,7 @@ def compute_bin(x, bin_edges):
         return bin
 
 
-@jit(nopython=True)
+@njit
 def numba_histogram(a, bin_edges):
     '''Copied from https://numba.pydata.org/numba-examples/examples/density_estimation/histogram/results.html'''
     n_bins = len(bin_edges) - 1
@@ -215,7 +215,7 @@ def numba_histogram(a, bin_edges):
 
 
 # FIXME: this function assumes non-overlapping epochs
-@jit(nopython=True)
+@njit
 def _epoch_spikes_numba(timestamps, event_times, tmin, tmax):
     trial_idx = [-1]
     n_in_trial = [0]
@@ -263,7 +263,7 @@ def _epoch_spikes_numba(timestamps, event_times, tmin, tmax):
     return trial, time
 
 
-@jit(nopython=True)
+@njit
 def create_trials_from_short(trial_idx, n_in_trial):
     n_all = sum(n_in_trial)
     trial = np.empty(n_all, dtype=np.int16)
@@ -276,7 +276,7 @@ def create_trials_from_short(trial_idx, n_in_trial):
     return trial
 
 
-@jit(nopython=True)
+@njit
 def concat_times(times, n_in_trial):
     n_all = sum(n_in_trial)
     time = np.empty(n_all, dtype=np.float64)

--- a/pylabianca/test/test_numba.py
+++ b/pylabianca/test/test_numba.py
@@ -11,3 +11,19 @@ def test_monotonic_unique_counts():
 
     assert (out[0] == np.array([ 2,  5,  8,  9, 10], dtype='int64')).all()
     assert (out[1] == np.array([3, 5, 2, 8, 4], dtype='int64')).all()
+
+
+def test_numba_select_spikes():
+    from pylabianca._numba import _select_spikes_numba
+
+    def select_spikes(spikes, trials, tri_sel):
+        msk = np.in1d(trials, tri_sel)
+        return spikes[msk]
+
+    spikes = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    trials = np.array([1, 1, 1, 2, 2, 2, 3, 3, 3, 4])
+    tri_sel = np.array([1, 3, 4])
+
+    out = _select_spikes_numba(spikes, trials, tri_sel)
+    expected = select_spikes(spikes, trials, tri_sel)
+    assert (out == expected).all()


### PR DESCRIPTION
## TODO:
- [ ] high-level API
- [ ] `backend` to select the numba version
- [ ] cache numba functions
- [ ] > 2 conditions
- [ ] test against zetapy (results similarity and speedup)
- [ ] example on same data as zetapy
- [ ] example on other data