### PR TITLE
FIX: xarray to dict sorted sessions alphabetically due to xarray groupby

### DIFF
--- a/pylabianca/test/test_utils.py
+++ b/pylabianca/test/test_utils.py
@@ -214,7 +214,7 @@ def test_xarr_dct_conversion():
     # because xarray sorts during groupby operation used in xarray_to_dict
     x_dct1 = {'C03': xarr1, 'A02': xarr2, 'W05': xarr1.copy()}
     xarr = pln.utils.dict_to_xarray(x_dct1)
-    x_dct2 = pln.utils.xarray_to_dict(xarr)
+    x_dct2 = pln.utils.xarray_to_dict(xarr, ensure_correct_reduction=False)
     compare_dicts(x_dct1, x_dct2)
 
     xarr_2 = pln.utils.dict_to_xarray(x_dct2)

--- a/pylabianca/test/test_utils.py
+++ b/pylabianca/test/test_utils.py
@@ -209,7 +209,6 @@ def test_xarr_dct_conversion():
     xarr = pln.utils.dict_to_xarray(x_dct1)
     # for some reason performing xarray_to_dict will not work without
     # assigning a name to the DataArray
-    xarr.name = 'data'
     x_dct2 = pln.utils.xarray_to_dict(xarr)
     compare_dicts(x_dct1, x_dct2)
 
@@ -217,7 +216,6 @@ def test_xarr_dct_conversion():
     # because xarray sorts during groupby operation used in xarray_to_dict
     x_dct1 = {'C03': xarr1, 'A02': xarr2, 'W05': xarr1.copy()}
     xarr = pln.utils.dict_to_xarray(x_dct1)
-
     x_dct2 = pln.utils.xarray_to_dict(xarr)
     compare_dicts(x_dct1, x_dct2)
 

--- a/pylabianca/test/test_utils.py
+++ b/pylabianca/test/test_utils.py
@@ -180,15 +180,15 @@ def test_xarr_dct_conversion():
 
     dim_names = ['cell', 'trial', 'time']
     xarr1 = xr.DataArray(np.random.rand(n_cells1, n_trials, n_times),
-                        dims=dim_names,
-                        coords={'cell': cell_names[:n_cells1],
-                                'trial': np.arange(n_trials),
-                                'time': time})
+                         dims=dim_names,
+                         coords={'cell': cell_names[:n_cells1],
+                                 'trial': np.arange(n_trials),
+                                 'time': time})
     xarr2 = xr.DataArray(np.random.rand(n_cells2, n_trials, n_times),
-                        dims=dim_names,
-                        coords={'cell': cell_names[:n_cells2],
-                                'trial': np.arange(n_trials),
-                                'time': time})
+                         dims=dim_names,
+                         coords={'cell': cell_names[:n_cells2],
+                                 'trial': np.arange(n_trials),
+                                 'time': time})
 
     load = np.concatenate([np.ones(10), np.ones(10) * 2])
     np.random.shuffle(load)

--- a/pylabianca/test/test_utils.py
+++ b/pylabianca/test/test_utils.py
@@ -207,8 +207,6 @@ def test_xarr_dct_conversion():
     x_dct1 = {'sub-A01': xarr1, 'sub-A02': xarr2}
 
     xarr = pln.utils.dict_to_xarray(x_dct1)
-    # for some reason performing xarray_to_dict will not work without
-    # assigning a name to the DataArray
     x_dct2 = pln.utils.xarray_to_dict(xarr)
     compare_dicts(x_dct1, x_dct2)
 
@@ -221,3 +219,10 @@ def test_xarr_dct_conversion():
 
     xarr_2 = pln.utils.dict_to_xarray(x_dct2)
     assert (xarr == xarr_2).all().item()
+
+    # for some reason performing a query will not work without
+    # assigning a name to the DataArray
+    # we test this here to be warned when this behavior is changed in xarray
+    with pytest.raises(ValueError, match='without providing an explicit name'):
+        xarr.name = None
+        xarr.query(cell='sub == "W05"')

--- a/pylabianca/test/test_utils.py
+++ b/pylabianca/test/test_utils.py
@@ -172,6 +172,14 @@ def test_xarr_dct_conversion():
     from string import ascii_lowercase
     import xarray as xr
 
+    def compare_dicts(x_dct1, x_dct2):
+        for key in x_dct1.keys():
+            assert (x_dct1[key].data == x_dct2[key].data).all()
+            coord_list = list(x_dct1[key].coords)
+            for coord in coord_list:
+                assert (x_dct1[key].coords[coord].values
+                        == x_dct2[key].coords[coord].values).all()
+
     letters = list(ascii_lowercase)
     n_cells1, n_cells2, n_trials, n_times = 10, 15, 20, 100
     time = np.linspace(-0.5, 1.5, num=n_times)
@@ -200,10 +208,11 @@ def test_xarr_dct_conversion():
 
     xarr = pln.utils.dict_to_xarray(x_dct1)
     x_dct2 = pln.utils.xarray_to_dict(xarr)
+    compare_dicts(x_dct1, x_dct2)
 
-    for key in x_dct1.keys():
-        assert (x_dct1[key].data == x_dct2[key].data).all()
-        coord_list = list(x_dct1[key].coords)
-        for coord in coord_list:
-            assert (x_dct1[key].coords[coord].values
-                    == x_dct2[key].coords[coord].values).all()
+    # test with non-sorted keys - this previously failed
+    # because xarray sorts during groupby operation used in xarray_to_dict
+    x_dct1 = {'C03': xarr1, 'A02': xarr2, 'W05': xarr1.copy()}
+    xarr = pln.utils.dict_to_xarray(x_dct1)
+    x_dct2 = pln.utils.xarray_to_dict(xarr)
+    compare_dicts(x_dct1, x_dct2)

--- a/pylabianca/test/test_utils.py
+++ b/pylabianca/test/test_utils.py
@@ -207,6 +207,9 @@ def test_xarr_dct_conversion():
     x_dct1 = {'sub-A01': xarr1, 'sub-A02': xarr2}
 
     xarr = pln.utils.dict_to_xarray(x_dct1)
+    # for some reason performing xarray_to_dict will not work without
+    # assigning a name to the DataArray
+    xarr.name = 'data'
     x_dct2 = pln.utils.xarray_to_dict(xarr)
     compare_dicts(x_dct1, x_dct2)
 
@@ -214,5 +217,9 @@ def test_xarr_dct_conversion():
     # because xarray sorts during groupby operation used in xarray_to_dict
     x_dct1 = {'C03': xarr1, 'A02': xarr2, 'W05': xarr1.copy()}
     xarr = pln.utils.dict_to_xarray(x_dct1)
+
     x_dct2 = pln.utils.xarray_to_dict(xarr)
     compare_dicts(x_dct1, x_dct2)
+
+    xarr_2 = pln.utils.dict_to_xarray(x_dct2)
+    assert (xarr == xarr_2).all().item()

--- a/pylabianca/utils.py
+++ b/pylabianca/utils.py
@@ -1045,6 +1045,10 @@ def xarray_to_dict(xarr, ses_name='sub', reduce_coords=True,
     xarr_dct = dict()
     session_order = pd.unique(xarr.coords[ses_name].values)
 
+    # for some reason we need a name to perform query
+    if xarr.name is None:
+        xarr.name = 'data'
+
     for ses in session_order:
         arr = xarr.query(cell=f'{ses_name} == "{ses}"')
         if reduce_coords:

--- a/pylabianca/utils.py
+++ b/pylabianca/utils.py
@@ -1043,8 +1043,10 @@ def dict_to_xarray(data, dim_name='cell', query=None, ses_name='sub'):
 def xarray_to_dict(xarr, ses_name='sub', reduce_coords=True,
                    ensure_correct_reduction=True):
     xarr_dct = dict()
+    session_order = pd.unique(xarr.coords[ses_name].values)
 
-    for lab, arr in xarr.groupby(ses_name):
+    for ses in session_order:
+        arr = xarr.query(cell=f'{ses_name} == "{ses}"')
         if reduce_coords:
             new_coords = dict()
             drop_coords = list()
@@ -1065,7 +1067,7 @@ def xarray_to_dict(xarr, ses_name='sub', reduce_coords=True,
                 arr = arr.drop(drop_coords)
                 arr = arr.assign_coords(new_coords)
 
-        xarr_dct[lab] = arr
+        xarr_dct[ses] = arr
 
     return xarr_dct
 

--- a/whats_new.md
+++ b/whats_new.md
@@ -9,6 +9,7 @@ DEV: Set up automated testing on CircleCI and code coverage tracking with codeco
 <br/>
 
 * FIX: `pylabianca.utils.xarray_to_dict()` used xarray `.groupby(session_coord)` to iterate over concatenated xarray and split it into dictionary of session name -> session xarray mappings. This had the unfortunate consequence of changing the order of sessions in the dictionary, if seession order was not alphabetical in the concatenated xarray. Now `pylabianca.utils.xarray_to_dict()` does not use `.groupby()` and preserves the order of sessions in the dictionary.
+* FIX: `SpikeEpochs.n_spikes(per_epoch=True)` used spike rate calculation to count spikes in each epoch. This was unnecessary (and possibly slow) and in rare cases could lead to wrong results (probably numerical error when multiplying spike rate by window duration and immediately turning to int, without rounding). Now `SpikeEpochs.n_spikes(per_epoch=True)` counts spikes directly using `pylabianca.utils._get_trial_boundaries`.
 * FIX: small fixes to `pylabianca.postproc.mark_duplicates()` - do not error when there are channels without any spikes
 
 <br/><br/>

--- a/whats_new.md
+++ b/whats_new.md
@@ -8,9 +8,9 @@ DEV: Set up automated testing on CircleCI and code coverage tracking with codeco
 
 <br/>
 
-* FIX: `pylabianca.utils.xarray_to_dict()` used xarray `.groupby(session_coord)` to iterate over concatenated xarray and split it into dictionary of session name -> session xarray mappings. This had the unfortunate consequence of changing the order of sessions in the dictionary, if seession order was not alphabetical in the concatenated xarray. Now `pylabianca.utils.xarray_to_dict()` does not use `.groupby()` and preserves the order of sessions in the dictionary.
+* FIX: `pylabianca.utils.xarray_to_dict()` used xarray `.groupby(session_coord)` to iterate over concatenated xarray and split it into dictionary of session name -> session xarray mappings. This had the unfortunate consequence of changing the order of sessions in the dictionary, if session order was not alphabetical in the concatenated xarray. Now `pylabianca.utils.xarray_to_dict()` does not use `.groupby()` and preserves the order of sessions in the dictionary.
 * FIX: `SpikeEpochs.n_spikes(per_epoch=True)` used spike rate calculation to count spikes in each epoch. This was unnecessary (and possibly slow) and in rare cases could lead to wrong results (probably numerical error when multiplying spike rate by window duration and immediately turning to int, without rounding). Now `SpikeEpochs.n_spikes(per_epoch=True)` counts spikes directly using `pylabianca.utils._get_trial_boundaries`.
-* FIX: small fixes to `pylabianca.postproc.mark_duplicates()` - do not error when there are channels without any spikes
+* FIX: small fixes to `pylabianca.postproc.mark_duplicates()` - do not error when there are channels without any spikes.
 
 <br/><br/>
 
@@ -28,7 +28,7 @@ DEV: Set up automated testing on CircleCI and code coverage tracking with codeco
 * ENH: around 10-fold speed up to `Spikes.epoch()` (20-fold for thousands of spikes and epoching events)
 * ENH: further speed up to `Spikes.epoch()` (around 5 - 13-fold) is now also possible by using `backend='numba'` (if numba is installed)
 * ENH: added `n_jobs` argument to `pylabianca.selectivity.cluster_based_selectivity()` to allow for parallel processing of cells
-ENH: allow for different percentile level in `pylabianca.stats.cluster_based_test_from_permutations()` using `percentile` argument.
+* ENH: allow for different percentile level in `pylabianca.stats.cluster_based_test_from_permutations()` using `percentile` argument.
 
 * ENH: `.plot_waveform()` method of `Spikes` and `SpikeEpochs` now allows to control the colormap to plot the waveform density with (`cmap` argument) and the number of y axis bins (`y_bins` argument)
 * ENH: added `colors` argument for explicit color control in `pylabianca.viz.plot_raster`

--- a/whats_new.md
+++ b/whats_new.md
@@ -37,7 +37,7 @@ DEV: Set up automated testing on CircleCI and code coverage tracking with codeco
 * ENH: allow to pass arguments to eventplot via `eventplot_kwargs` from `pylabianca.viz.plot_raster()` and `pylabianca.viz.plot_spikes()`
 
 * ENH: added `pylabianca.utils.cellinfo_from_xarray()` function to extract/reconstruct cellinfo dataframe from xarray DataArray coordinates.
-* ENH: `pylabianca.utils.xr_find_nested_dims()` now returns "nested" xarray coordinates also for coordinate tuplples (for example `('cell', 'trial')` - which happens often after concatenating multiple xarray sessions)
+* ENH: `pylabianca.utils.xr_find_nested_dims()` now returns "nested" xarray coordinates also for coordinate tuples (for example `('cell', 'trial')` - which happens often after concatenating multiple xarray sessions)
 * ENH: added `copy_cellinfo` argument to `pylabianca.selectivity.cluster_based_selectivity()`. It allows to select which cellinfo columns are copied to the selectivity dataframe.
 * ENH: expose `.to_spiketools()` as `SpikeEpochs` method (previously it was only available as a function in `pylabianca.io` module)
 * ENH: added `pylabianca.utils.dict_to_xarray()` function to convert dictionary of xarrays (multiple sessions / subjects) to one concatenated xarray DataArray

--- a/whats_new.md
+++ b/whats_new.md
@@ -2,6 +2,15 @@
 
 ## DEV (upcoming version 0.4)
 
+## Version 0.3.1
+
+DEV: Set up automated testing on CircleCI and code coverage tracking with codecov.com
+
+<br/>
+
+* FIX: `pylabianca.utils.xarray_to_dict()` used xarray `.groupby(session_coord)` to iterate over concatenated xarray and split it into dictionary of session name -> session xarray mappings. This had the unfortunate consequence of changing the order of sessions in the dictionary, if seession order was not alphabetical in the concatenated xarray. Now `pylabianca.utils.xarray_to_dict()` does not use `.groupby()` and preserves the order of sessions in the dictionary.
+* FIX: small fixes to `pylabianca.postproc.mark_duplicates()` - do not error when there are channels without any spikes
+
 <br/><br/>
 
 ## Version 0.3
@@ -31,6 +40,7 @@ ENH: allow for different percentile level in `pylabianca.stats.cluster_based_tes
 * ENH: added `copy_cellinfo` argument to `pylabianca.selectivity.cluster_based_selectivity()`. It allows to select which cellinfo columns are copied to the selectivity dataframe.
 * ENH: expose `.to_spiketools()` as `SpikeEpochs` method (previously it was only available as a function in `pylabianca.io` module)
 * ENH: added `pylabianca.utils.dict_to_xarray()` function to convert dictionary of xarrays (multiple sessions / subjects) to one concatenated xarray DataArray
+* EHN: added `pylabianca.utils.xarray_to_dict()` function to convert xarray DataArray to dictionary of xarrays (useful when splitting xarray DataArray to multiple sessions / subjects)
 * ENH: added `pylabianca.utils.assign_session_coord()` function to assign session / subject coordinate to xarray DataArray (useful when concatenating multiple sessions / subjects- using `pylabianca.utils.dict_to_xarray()`)
 
 * ENH: allow to select trials with boolean mask for `SpikeEpochs` objects (e.g. `spk_epochs[np.array([True, False, True])]` or `spk_epochs[my_mask]` where `my_mask` is a boolean array of length `len(spk_epochs)`)


### PR DESCRIPTION
`pylabianca.utils.xarray_to_dict` unintentionally sorted sessions alphabetically (side effect of using xarray `.groupby()` operation on session coord. This broke the round-trip shown below:
```python
dct_of_xarr = pln.utils.xarray_to_dict(xarr, ses_name='session')
xarr2 = dict_to_xarray(dct_of_xarr)
```

BTW locally I have "ValueError: unable to convert unnamed DataArray to a Dataset without providing an explicit name" when doing `xarray_to_dict(xarr)` for some reason... Let's see if they happen on CI too.