### PR TITLE
Fix compute_percent_selective

### DIFF
--- a/pylabianca/selectivity.py
+++ b/pylabianca/selectivity.py
@@ -172,12 +172,9 @@ def compute_selectivity_continuous(frate, compare='image', n_perm=500,
     cells = frate.cell.values
 
     # perm
-    dims = ['perm', 'cell']
-    coords = {'perm': np.arange(n_perm) + 1,
-              'cell': cells}
-    if has_time:
-        dims.append('time')
-        coords['time'] = frate.time.values
+    dims = ['perm'] + frate_dims[1:]
+    coords = {'cell': frate.coords[dim].values.copy()
+              for dim in frate_dims[1:]}
 
     if n_perm > 0:
         results['dist'] = xr.DataArray(data=results['dist'], dims=dims,
@@ -188,7 +185,6 @@ def compute_selectivity_continuous(frate, compare='image', n_perm=500,
         results = dict()
 
     # stat
-    coords = {k: coords[k] for k in dims[1:]}
     results['stat'] = xr.DataArray(
         data=use_data, dims=dims[1:], coords=coords, name=stat_name)
 

--- a/pylabianca/selectivity.py
+++ b/pylabianca/selectivity.py
@@ -173,8 +173,7 @@ def compute_selectivity_continuous(frate, compare='image', n_perm=500,
 
     # perm
     dims = ['perm'] + frate_dims[1:]
-    coords = {'cell': frate.coords[dim].values.copy()
-              for dim in frate_dims[1:]}
+    coords = {dim: frate.coords[dim].values.copy() for dim in frate_dims[1:]}
 
     if n_perm > 0:
         results['dist'] = xr.DataArray(data=results['dist'], dims=dims,

--- a/pylabianca/selectivity.py
+++ b/pylabianca/selectivity.py
@@ -718,13 +718,9 @@ def compute_percent_selective(selectivity, threshold=None, dist=None,
                         f'xarray.Dataset. Got {type(selectivity)}.')
 
     # test that dims are ['cell'] or ['cell', 'time']
-    bad_dim_msg = 'Selectivity must have "cell" as the first dimension'
-    if isinstance(selectivity, xr.DataArray):
-        if not selectivity.dims[0] == 'cell':
-            raise ValueError(bad_dim_msg)
-    elif isinstance(selectivity, xr.Dataset):
-        if not selectivity['stat'].dims[0] == 'cell':
-            raise ValueError(bad_dim_msg)
+    bad_dim_msg = 'Selectivity must contain "cell" dimension'
+    if not 'cell' in selectivity.dims:
+        raise ValueError(bad_dim_msg)
 
     apply_func = lambda arr: arr.sum(dim='cell')
 
@@ -778,7 +774,7 @@ def compute_percent_selective(selectivity, threshold=None, dist=None,
             perm_sel, groupby, apply_fn=apply_func)
         perc_sel_perm = (n_sel_perm / n_total) * 100.
         perm_thresh = find_percentile_threshold(
-            perc_sel_perm, percentile=5, tail='pos', perm_dim=0
+            perc_sel_perm, percentile=5, tail='pos', perm_dim=None
         )
 
         data_dict = dict(stat=perc_sel, thresh=perm_thresh, dist=perc_sel_perm)

--- a/pylabianca/test/test_selectivity.py
+++ b/pylabianca/test/test_selectivity.py
@@ -264,3 +264,15 @@ def test_compute_percent_selective():
     perc = pln.selectivity.compute_percent_selective(
             sel, threshold=thresh1, dist=perm)
     assert (perc.stat > perc.thresh).mean(dim='time').item() > 0.035
+
+    ds = xr.Dataset({'sel': sel, 'dist': perm})
+    perc_ds = pln.selectivity.compute_percent_selective(
+            ds, threshold=thresh1)
+    are_same = (perc_ds == perc).all()
+    for key in ['stat', 'thresh', 'dist']:
+        assert are_same[key].item()
+
+    perc_ds = pln.selectivity.compute_percent_selective(
+        ds, percentile=5)
+
+    assert (perc_ds.stat > perc_ds.thresh).mean(dim='time').item() > 0.05

--- a/pylabianca/test/test_selectivity.py
+++ b/pylabianca/test/test_selectivity.py
@@ -265,7 +265,7 @@ def test_compute_percent_selective():
             sel, threshold=thresh1, dist=perm)
     assert (perc.stat > perc.thresh).mean(dim='time').item() > 0.035
 
-    ds = xr.Dataset({'sel': sel, 'dist': perm})
+    ds = xr.Dataset({'stat': sel, 'dist': perm})
     perc_ds = pln.selectivity.compute_percent_selective(
             ds, threshold=thresh1)
     are_same = (perc_ds == perc).all()

--- a/pylabianca/utils.py
+++ b/pylabianca/utils.py
@@ -1490,8 +1490,11 @@ def nested_groupby_apply(array, groupby, apply_fn=None):
     ----------
     array : xarray.DataArray
         DataArray to groupby and apply function to.
-    groupby : list
-        List of dimensions/variables to apply groupby operations to.
+    groupby : str | list | None
+        Dimensions/variables to apply groupby operation to. Can be:
+        * str: single variable is used to group by.
+        * list: multiple variables are used to group by.
+        * None: no groupby operation is performed.
     apply_fn : function
         Function to apply to grouped DataArray. If ``None``, the mean along
         'trial' dimension is used.
@@ -1505,6 +1508,11 @@ def nested_groupby_apply(array, groupby, apply_fn=None):
     if apply_fn is None:
         # average over trial by default
         apply_fn = lambda arr: arr.mean(dim='trial')
+
+    if groupby is None:
+        return apply_fn(array)
+    elif isinstance(groupby, str):
+        groupby = [groupby]
 
     if len(groupby) == 1:
         return array.groupby(groupby[0]).apply(apply_fn)


### PR DESCRIPTION
Moving changes from unorganized branch, this is needed to conveniently work with zeta now. The changes:
* FIX: `compute_percent_selective` to work with more dimensions then expected - this is very useful if selectivity array is split by condition (has condition dimensions), now `compute_percent_selective` retains these
* ENH: multi-variable ("nested") groupby is now also allowed, at the same time simplying the code