### PR TITLE
Save data to fieldtrip format

### DIFF
--- a/doc/data_formats.md
+++ b/doc/data_formats.md
@@ -1,7 +1,7 @@
-# Spike data fromats
+# Spike data formats
 
-Pylabianca natively reads Osort, Combinato and FieldTrip data formats.  
-Other formats can be easily read via python [neo](https://neo.readthedocs.io/en/latest/) package. An example of reading spike data from Plexon `.nex` file (NeuroExplorer) using neo can be found [here]().
+Pylabianca natively reads Osort, Combinato and FieldTrip data formats.
+Other formats can be easily read via python [neo](https://neo.readthedocs.io/en/latest/) package. An example of reading spike data from Plexon `.nex` file (NeuroExplorer) using neo can be found [here](doc/spike-triggered_analysis.ipynb).
 Support for other formats will be added in future. If there is a file format you would like to read directly to pylabianca, without using neo - drop us an issue on GitHub!
 
 ## FieldTrip data format
@@ -9,8 +9,8 @@ The format used by fieldtrip is described in more detail in [the FieldTrip spike
 This format uses matlab files (`*.mat`).
 
 ### raw spikes
-"Raw" spikes FieldTrip format - spike times are in timestamps and are not "epoched" yet.  
-The data variable is a structure with the follwing fields:
+FieldTrip format for continuous ("raw") spikes. This format is used to represent spike times prior to epoching with respect to events of interest. Spike times are stored in timestamps.
+The data variable contains a structure with the following fields:
 ```
         label: {1×21 cell}
     timestamp: {1×21 cell}
@@ -25,15 +25,26 @@ The data variable is a structure with the follwing fields:
 * `unit` - 1 x n_neurons cell array with 1 x n_spikes vector of what seems to be unit cluster ID's (in the example data it is all nan)
 * `hdr` - file header information
 
+#### reading / writing
 This format can be read by `pylabianca.io.read_fieldtrip(path_to_file, kind='raw')`.
+To save to this file format use `.to_fieldtrip()` method of `pylabianca.Spikes` object. When saving to fieldtrip raw spikes format the following additional fields may be stored in the file. Information stored in these fields does not have an equivalent in standard fieldtrip format:
+* `cellinfo` - a structure containing field corresponding to columns of `Spikes.cellinfo` pandas DataFrame. Each field stores an array / cell array of `n_neurons` length. Added only if `Spikes.cellinfo` is not `None`.
+* `waveform_time` - `n_samples` array of time labels corresponding to waveforms time dimension. Added only if `Spikes.waveform_time` attribute is not `None`.
+
 
 ### spikeTrials
 FieldTrip format for epoched spiking data. We now additionally have the following fields:
 * `time` - spike times in seconds with respect to trigger onset
 * `trial` for each spike - information about the trial in which it fires
 * `trialtime`:  `n_trials x 2` (time in seconds of the trial beginning and end - for each trial)
+* `trialinfo` - optional field with `n_trials x N` array. Contains trial-level additional information (can store data such as participant response, correctness, reaction time, trial condition, etc.)
 
+#### reading / writing
 This format can be read by `pylabianca.io.read_fieldtrip(path_to_file, kind='trials')`.
+To save to this file format use `.to_fieldtrip()` method of `pylabianca.SpikeEpochs` object. When saving to fieldtrip spikeTrials format the following additional fields may be stored in the file. Information stored in these fields does not have an equivalent in standard fieldtrip format:
+* `trialinfo_columns` - column names for `trialinfo`. Added only if `SpikeEpochs.metadata` is not `None` (in which case `trialinfo` field is added).
+* `cellinfo` - a structure containing field corresponding to columns of `SpikeEpochs.cellinfo` pandas DataFrame. Each field stores an array / cell array of `n_neurons` length. Added only if `SpikeEpochs.cellinfo` is not `None`.
+* `waveform_time` - `n_samples` array of time labels corresponding to waveforms time dimension. Added only if `SpikeEpochs.waveform_time` attribute is not `None`.
 
 ## Osort output data
 Format used as output by the Osort sorter.
@@ -47,25 +58,25 @@ The data variable is a structure with the follwing fields:
 * allSpikesCorrFree - also waveforms, but different from newSpikesNegative (FIX - more info needed here)
 * scalingFactor - scaling factor for the waveforms (?), currently not used because it frequently is NaN and the read scaling factor has to be read from Neuralynx file header.  (FIX - more info needed here)
 
-This format uses one file per lead (microelectrode), so a path to folder (not file) is needed to read multiple channels.  
-This format can be read by `pylabianca.io.read_osort(path_to_folder, format='standard')`.  
-This function can be used to read only some of the channels, reading vs not reading waveforms etc. - for more details see the docstring.  
+This format uses one file per lead (microelectrode), so a path to folder (not file) is needed to read multiple channels.
+This format can be read by `pylabianca.io.read_osort(path_to_folder, format='standard')`.
+This function can be used to read only some of the channels, reading vs not reading waveforms etc. - for more details see the docstring.
 
 ### "mm" format
-Slightly modified and cleaned up variant of the Osort output format.  
+Slightly modified and cleaned up variant of the Osort output format.
 The data variable is a structure with the follwing fields:
 * `cluster_id` - vector of cluster ids, one per cell (not one per spike as in "standard" format)
 * `timestamp` - cell array, where each cell contains vector of timestamps for respective neuron (so `data.timestamp{1}` contains timestamps for the unit formed by the first cluster in `data.cluster_id`)
 * `waveform` - cell array, where each cell contains `n_spikes x n_samples` matrix of waveforms for respective neuron
 * `alignment` - cell array of alignment information (the aligment - negative, positive or mixed for the chosen unit)
 * `threshold` - vector of spike SD thresholds used for spike detection
-* `channel` - cell array of channel names (one channel name per 
+* `channel` - cell array of channel names (one channel name per
 
-This format uses only one file per sorting (not one per lead/microchannel as in Osort "standard" format).  
-This format can be read by `pylabianca.io.read_osort(path_to_file, format='mm')`.  
-This function can be used to read only some of the channels, reading vs not reading waveforms etc. - for more details see the docstring.  
+This format uses only one file per sorting (not one per lead/microchannel as in Osort "standard" format).
+This format can be read by `pylabianca.io.read_osort(path_to_file, format='mm')`.
+This function can be used to read only some of the channels, reading vs not reading waveforms etc. - for more details see the docstring.
 
 ## Combinato output data
-[FIX - add more info here]  
-  
+Standard combinato multi-folder data.
+
 This format can be read by `pylabianca.io.read_combinato(path, alignment='both')`.

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - pandas>=2.1.2
   - pip
   - scikit-learn>=1.3.2
+  - scikit-image
   - scipy>=1.11.3
   - setuptools
   - tqdm>=4.66.1

--- a/pylabianca/io.py
+++ b/pylabianca/io.py
@@ -275,11 +275,12 @@ def _write_filedtrip_raw(spk, filename):
     # Initialize structure for FieldTrip format
     spikes = {'timestamp': [], 'label': []}
     spikes['dimord'] = '{chan}_lead_time_spike'
+    spikes['hdr'] = dict(FileHeader=dict(Frequency=spk.sfreq))
 
     # Loop over cells
     n_units = spk.n_units()
     for cell_idx in range(n_units):
-        spikes['timestamp'].append(spk.timestamp[cell_idx])
+        spikes['timestamp'].append(spk.timestamps[cell_idx])
         spikes['label'].append(spk.cell_names[cell_idx])
 
     spikes = _waveform_to_ft(spk, spikes)

--- a/pylabianca/io.py
+++ b/pylabianca/io.py
@@ -233,16 +233,16 @@ def _get_ft_cellinfo(data):
 #       data['hdr'].item()['FileHeader'].item()['Frequency'].item()
 #       (what if waveform_time and timestamp sfreq are different ?
 #        first check if waveform_time is present ?)
-def _write_filedtrip_trials(spk, filename):
+def _write_filedtrip_trials(spk, filepath):
     """
-    Saves spike data to FieldTrip-compatible .mat file.
+    Saves SpikeEpochs data to FieldTrip-compatible .mat file.
 
     Parameters
     ----------
     spk : SpikeEpochs
         SpikeEpochs object to save.
-    filename : str
-        The name of the output .mat file.
+    filepath : str
+        Path to the output .mat file.
     """
     from scipy.io import savemat
 
@@ -268,20 +268,20 @@ def _write_filedtrip_trials(spk, filename):
         spikeTrials['trialinfo_columns'] = spk.metadata.columns.tolist()
 
     # Save to a .mat file using scipy.io.savemat
-    savemat(filename, {'spike': spikeTrials})
-    # use some logging later: print(f"Spike trials saved to {filename}")
+    savemat(filepath, {'spike': spikeTrials})
+    # use some logging later: print(f"Spike trials saved to {filepath}")
 
 
-def _write_filedtrip_raw(spk, filename):
+def _write_filedtrip_raw(spk, filepath):
     """
-    Saves spike data to FieldTrip-compatible .mat file.
+    Saves Spikes data to FieldTrip-compatible .mat file.
 
     Parameters
     ----------
     spk : Spikes
         Spikes object to save.
-    filename : str
-        The name of the output .mat file.
+    filepath : str
+        Path to the output .mat file.
     """
     from scipy.io import savemat
 
@@ -300,7 +300,7 @@ def _write_filedtrip_raw(spk, filename):
     spikes = _cellinfo_to_ft(spk, spikes)
 
     # Save to a .mat file using scipy.io.savemat
-    savemat(filename, {'spike': spikes})
+    savemat(filepath, {'spike': spikes})
 
 
 def _waveform_to_ft(spk, spikeTrials):

--- a/pylabianca/spikes.py
+++ b/pylabianca/spikes.py
@@ -423,6 +423,18 @@ class SpikeEpochs():
         from .io import to_spiketools
         return to_spiketools(self, picks)
 
+    def to_fieldtrip(self, filename):
+        """
+        Saves spike data to FieldTrip-compatible .mat file.
+
+        Parameters
+        ----------
+        filename : str
+            The name of the output .mat file.
+        """
+        from .io import _write_filedtrip_trials
+        _write_filedtrip_trials(self, filename)
+
     def __getitem__(self, selection):
         '''Select trials using an array of int / bool or metadata query.'''
         if isinstance(selection, str):

--- a/pylabianca/spikes.py
+++ b/pylabianca/spikes.py
@@ -423,17 +423,17 @@ class SpikeEpochs():
         from .io import to_spiketools
         return to_spiketools(self, picks)
 
-    def to_fieldtrip(self, filename):
+    def to_fieldtrip(self, filepath):
         """
-        Saves spike data to FieldTrip-compatible .mat file.
+        Saves SpikeEpochs data to FieldTrip-compatible .mat file.
 
         Parameters
         ----------
-        filename : str
-            The name of the output .mat file.
+        filepath : str
+            Path to the output .mat file.
         """
         from .io import _write_filedtrip_trials
-        _write_filedtrip_trials(self, filename)
+        _write_filedtrip_trials(self, filepath)
 
     def __getitem__(self, selection):
         '''Select trials using an array of int / bool or metadata query.'''
@@ -1050,17 +1050,17 @@ class Spikes(object):
             cell_names=cell_names, cellinfo=cellinfo)
         return spk_epochs
 
-    def to_fieldtrip(self, fpath):
+    def to_fieldtrip(self, filepath):
         """
-        Saves spike data to FieldTrip-compatible .mat file.
+        Saves Spikes data to FieldTrip-compatible .mat file.
 
         Parameters
         ----------
-        filename : str
-            The name of the output .mat file.
+        filepath : str
+            Path to the output .mat file.
         """
         from pylabianca.io import _write_filedtrip_raw
-        _write_filedtrip_raw(self, fpath)
+        _write_filedtrip_raw(self, filepath)
 
     def merge(self, picks):
         '''Merge spikes from multiple cells into one. Operates in-place.

--- a/pylabianca/spikes.py
+++ b/pylabianca/spikes.py
@@ -1050,6 +1050,18 @@ class Spikes(object):
             cell_names=cell_names, cellinfo=cellinfo)
         return spk_epochs
 
+    def to_fieldtrip(self, fpath):
+        """
+        Saves spike data to FieldTrip-compatible .mat file.
+
+        Parameters
+        ----------
+        filename : str
+            The name of the output .mat file.
+        """
+        from pylabianca.io import _write_filedtrip_raw
+        _write_filedtrip_raw(self, fpath)
+
     def merge(self, picks):
         '''Merge spikes from multiple cells into one. Operates in-place.
 

--- a/whats_new.md
+++ b/whats_new.md
@@ -13,6 +13,7 @@
 
 <br/>
 
+* ENH: `Spikes` and `SpikeEpochs` can now be saved to FieldTrip data format. To maintain the input-output roundtrip (data saved and then read are identical) additional non-standard fields are added to the file when `.metadata` or `.cellinfo` are used. These additional fields should not conflict with using the file in FieldTrip.
 * ENH: add `pylabianca.utils._inherit_from_xarray()` to allow inheriting metadata (cell or trial-level additional information) from xarray DataArray to new xarray DataArray.
 * ENH: `pylabianca.utils.dict_to_xarray()` now allows to pass dictionary of `xarray.Dataset` as input.
 * ENH: `pylabianca.utils.xarray_to_dict()` has been sped up considerably. It relies on sessions being concatenated along the cell dimension (so each session being a contiguous block of cells).
@@ -41,6 +42,7 @@
 <br/>
 
 * DOC: add docstring to `pylabianca.selectivity.assess_selectivity()`
+* DOC: improve data format docs about FieldTrip data format.
 
 <br/><br/>
 


### PR DESCRIPTION
Allows to save Spikes and SpikeEpochs to fieldtrip format.

## TODOs:
- [x] add notes about additional info in data fromats page
- [x] finish tests
- [x] check docstrings
- [x] add whats new