### PR TITLE
universal find_cells instead of find_cells_by_cluster_id 

### DIFF
--- a/doc/data_formats.md
+++ b/doc/data_formats.md
@@ -51,20 +51,20 @@ Format used as output by the Osort sorter.
 This format uses matlab files (`*.mat`).
 
 ### standard format
-The data variable is a structure with the follwing fields:
+The data variable is a structure with the following fields:
 * `assignedNegative` - a vector of cluster id per each spike
 * `newSpikesNegative` - waveforms, one per spike
 * `newTimestampsNegative` - timestamps for all the spikes
 * allSpikesCorrFree - also waveforms, but different from newSpikesNegative (FIX - more info needed here)
 * scalingFactor - scaling factor for the waveforms (?), currently not used because it frequently is NaN and the read scaling factor has to be read from Neuralynx file header.  (FIX - more info needed here)
 
-This format uses one file per lead (microelectrode), so a path to folder (not file) is needed to read multiple channels.
+This format uses one file per lead (micro-electrode), so a path to folder (not file) is needed to read multiple channels.
 This format can be read by `pylabianca.io.read_osort(path_to_folder, format='standard')`.
 This function can be used to read only some of the channels, reading vs not reading waveforms etc. - for more details see the docstring.
 
 ### "mm" format
 Slightly modified and cleaned up variant of the Osort output format.
-The data variable is a structure with the follwing fields:
+The data variable is a structure with the following fields:
 * `cluster_id` - vector of cluster ids, one per cell (not one per spike as in "standard" format)
 * `timestamp` - cell array, where each cell contains vector of timestamps for respective neuron (so `data.timestamp{1}` contains timestamps for the unit formed by the first cluster in `data.cluster_id`)
 * `waveform` - cell array, where each cell contains `n_spikes x n_samples` matrix of waveforms for respective neuron
@@ -72,7 +72,7 @@ The data variable is a structure with the follwing fields:
 * `threshold` - vector of spike SD thresholds used for spike detection
 * `channel` - cell array of channel names (one channel name per
 
-This format uses only one file per sorting (not one per lead/microchannel as in Osort "standard" format).
+This format uses only one file per sorting (not one per lead/micro-channel as in Osort "standard" format).
 This format can be read by `pylabianca.io.read_osort(path_to_file, format='mm')`.
 This function can be used to read only some of the channels, reading vs not reading waveforms etc. - for more details see the docstring.
 

--- a/pylabianca/io.py
+++ b/pylabianca/io.py
@@ -410,7 +410,7 @@ def read_combinato(path, label=None, alignment='both'):
 
                 types = np.asarray(sorting_file['types'])
                 # find SUs (or SUs and MUs)
-                is_SU = np.in1d(types[:, -1], types_oi)
+                is_SU = np.isin(types[:, -1], types_oi)
 
                 if not is_SU.any():
                     continue
@@ -421,7 +421,7 @@ def read_combinato(path, label=None, alignment='both'):
                 has_content = True
                 groups_oi = types[is_SU, 0]
                 groups = np.asarray(sorting_file['groups'])
-                groups_sel = np.in1d(groups[:, 1], groups_oi)
+                groups_sel = np.insin(groups[:, 1], groups_oi)
                 groups = groups[groups_sel, :]
 
                 spike_classes = np.asarray(sorting_file['classes'])
@@ -435,7 +435,7 @@ def read_combinato(path, label=None, alignment='both'):
                 for grp in groups_oi:
                     msk = groups[:, 1] == grp
                     this_classes = groups[msk, 0]
-                    class_msk = np.in1d(spike_classes, this_classes)
+                    class_msk = np.isin(spike_classes, this_classes)
 
                     idx = spike_indices[class_msk]
                     # some groups can be empty with label that was not updated
@@ -618,7 +618,7 @@ def read_osort(path, waveform=True, channels='all', format='mm',
             # find cluster ids
             if not use_usenegative:
                 cluster_ids = np.unique(this_cluster_id)
-                msk = np.in1d(cluster_ids, ignore_cluster)
+                msk = np.isin(cluster_ids, ignore_cluster)
                 if msk.any():
                     cluster_ids = cluster_ids[~msk]
             else:

--- a/pylabianca/postproc.py
+++ b/pylabianca/postproc.py
@@ -257,7 +257,7 @@ def mark_duplicates(spike_data_dir, first_channel, fig_dir=None,
         packs.append(this_pack)
         current_ch_idx += 8
 
-    units_in_pack = [np.where(np.in1d(unit_channel, pack))[0]
+    units_in_pack = [np.where(np.isin(unit_channel, pack))[0]
                      for pack in packs]
 
     # calculate measures

--- a/pylabianca/spikes.py
+++ b/pylabianca/spikes.py
@@ -476,7 +476,7 @@ class SpikeEpochs():
         # for each cell select relevant trials:
         for cell_idx in range(len(self.trial)):
             cell_tri = self.trial[cell_idx]
-            sel = np.in1d(cell_tri, tri_idx)
+            sel = np.isin(cell_tri, tri_idx)
             new_time.append(self.time[cell_idx][sel])
 
             this_tri = (cell_tri[sel, None] == tri_idx[None, :]).argmax(axis=1)
@@ -785,7 +785,7 @@ class Spikes(object):
         '''
         # event_id support
         if event_id is not None:
-            use_events = np.in1d(events[:, -1], event_id)
+            use_events = np.isin(events[:, -1], event_id)
             if not np.any(use_events):
                 raise ValueError(
                     'No events of any of the types ({}) found.'.format(
@@ -1272,7 +1272,7 @@ def _drop_cells(spk, drop):
     # invert drop to pick and use pick_cells
     all_idx = np.arange(spk.n_units())
     drop = _deal_with_picks(spk, drop)
-    is_dropped = np.in1d(all_idx, drop)
+    is_dropped = np.isin(all_idx, drop)
     retain_idx = np.where(~is_dropped)[0]
     return spk.pick_cells(retain_idx)
 

--- a/pylabianca/stats.py
+++ b/pylabianca/stats.py
@@ -165,7 +165,8 @@ def cluster_based_test(frate, compare='image', cluster_entry_pval=0.05,
 #      machinery into a separate xarray-agnostic function
 # ENH: return borsar.Clusters object as output
 def cluster_based_test_from_permutations(data, perm_data, tail='both',
-                                         adjacency=None, percentile=5):
+                                         adjacency=None, percentile=5,
+                                         threshold=None):
     '''Performs a cluster-based test from precalculated permutations.
 
     This function should get data ready for cluster-based permutation test
@@ -199,6 +200,9 @@ def cluster_based_test_from_permutations(data, perm_data, tail='both',
         the 2.5th (``percentile / 2``) and 97.5th (``100 - (percentile / 2)``)
         percentiles are used as thresholds. The percentile should be between
         0 and 100.
+    threshold : float
+        Threshold to use for clustering. If ``None`` then the threshold is
+        calculated using the ``percentile`` parameter.
 
     Returns
     -------
@@ -216,17 +220,20 @@ def cluster_based_test_from_permutations(data, perm_data, tail='both',
     assert isinstance(perm_data, xr.DataArray)
 
     perm_dim_name, _ = _find_dim(perm_data)
-    thresholds = find_percentile_threshold(
-        perm_data, perm_dim=perm_dim_name,
-        percentile=percentile, tail=tail, as_xarray=False
-    )
+
+    if threshold is None:
+        thresholds = find_percentile_threshold(
+            perm_data, perm_dim=perm_dim_name,
+            percentile=percentile, tail=tail, as_xarray=False
+        )
+    else:
+        thresholds = threshold
 
     # clusters on actual data
     clusters, cluster_stats = borsar.find_clusters(
         data.values, thresholds, backend='borsar', adjacency=adjacency)
 
     # check which are pos and which neg:
-    is_neg = cluster_stats < 0
     cluster_distr_pos = list()
     cluster_distr_neg = list()
 
@@ -269,7 +276,7 @@ def cluster_based_test_from_permutations(data, perm_data, tail='both',
 
 
 # CONSIDER: move the xarray "clothing" function somewhere to utils
-#           something like this is used in many places of pylabianca
+#           something like this is used in compute_selectivity_continuous
 # CONSIDER: especially when using one-tail one may expect that percentile
 #           95 works adequately, not 5
 #           we later do 100 - percentile, but that seems counter-intuitive

--- a/pylabianca/test/test_utils.py
+++ b/pylabianca/test/test_utils.py
@@ -129,6 +129,13 @@ def test_find_cells():
     with pytest.raises(ValueError, match=msg):
         find_cells(spk, numpy=[1, 2, 3])
 
+    # tiling length one search features:
+    spk.cellinfo.loc[0:1, 'cluster'] = [17, 23]
+    spk.cellinfo.loc[2:3, 'cluster'] = [17, 23]
+
+    row_idx = find_cells(spk, channel=2, cluster=[17, 23])
+    assert (row_idx == [2, 3]).all()
+
 
 def test_spike_centered_windows():
     # simple case - one spike per trial

--- a/pylabianca/test/test_utils.py
+++ b/pylabianca/test/test_utils.py
@@ -78,7 +78,14 @@ def test_cellinfo_from_xarray():
 def test_find_cells():
     spk = create_random_spikes(n_trials=10, n_cells=10)
     channel = (np.tile(np.arange(5)[:, None], [1, 2]) + 1).ravel()
-    cluster_id = np.random.randint(50, 1000, size=10)
+
+    # generate unique cluster ids
+    is_unique = False
+    while not is_unique:
+        cluster_id = np.random.randint(50, 1000, size=10)
+        is_unique = len(np.unique(cluster_id)) == 10
+
+    # create and assign cellinfo
     spk.cellinfo = pd.DataFrame({'channel': channel, 'cluster': cluster_id})
 
     # test _get_cellinfo
@@ -102,6 +109,7 @@ def test_find_cells():
     with pytest.raises(ValueError, match=msg):
         info = pln.utils._get_cellinfo(spk2)
 
+    # test find_cells
     cell_idx = 3
     cluster = cluster_id[cell_idx]
     idx = find_cells(spk, cluster=cluster)

--- a/pylabianca/utils.py
+++ b/pylabianca/utils.py
@@ -631,7 +631,7 @@ def _get_cellinfo(inst):
     return cellinfo
 
 
-def find_cells(inst, **features, not_found='error'):
+def find_cells(inst, not_found='error', **features):
     '''Find cell indices that create given clusters on specific channel.'''
     from numbers import Number
 

--- a/pylabianca/utils.py
+++ b/pylabianca/utils.py
@@ -606,6 +606,7 @@ def _get_trial_boundaries(spk, cell_idx):
 
 
 def _get_cellinfo(inst):
+    '''Obtain the cellinfo dataframe from multiple input types.'''
     from .spikes import Spikes, SpikeEpochs
     spike_objects = (Spikes, SpikeEpochs)
 
@@ -632,7 +633,19 @@ def _get_cellinfo(inst):
 
 
 def find_cells(inst, not_found='error', **features):
-    '''Find cell indices that create given clusters on specific channel.'''
+    '''Find cell indices that fullfil search criteria.
+
+    Parameters
+    ----------
+    inst: pylabianca.Spikes | pylabianca.SpikeEpochs | xarray.DataArray | pandas.DataFrame
+        Object containing cellinfo dataframe.
+    not_found: str
+        Whether to error (``'error'``, default) or warn (``'warn'``) when
+        some search items were not found.
+    **features:
+        Keyword argument with search criteria. Keys refer to column names in
+        the cellinfo dataframe and values are the values to search for.
+        '''
     from numbers import Number
 
     cellinfo = _get_cellinfo(inst)

--- a/pylabianca/utils.py
+++ b/pylabianca/utils.py
@@ -605,23 +605,21 @@ def _get_trial_boundaries(spk, cell_idx):
     return trial_boundaries, tri_num
 
 
-# TODO: first ~18 lines could be put in get_cellinfo function
-def find_cells_by_cluster_id(cellinfo_source, cluster_ids, channel=None):
-    '''Find cell indices that create given clusters on specific channel.'''
+def _get_cellinfo(inst):
     from .spikes import Spikes, SpikeEpochs
     spike_objects = (Spikes, SpikeEpochs)
 
-    if isinstance(cellinfo_source, spike_objects):
-        cellinfo = cellinfo_source.cellinfo
-    elif isinstance(cellinfo_source, pd.DataFrame):
-        cellinfo = cellinfo_source
+    if isinstance(inst, spike_objects):
+        cellinfo = inst.cellinfo
+    elif isinstance(inst, pd.DataFrame):
+        cellinfo = inst
     else:
-        msg = ('``cellinfo_source`` has to be a Spikes, SpikeEpochs, xarray '
+        msg = ('``inst`` has to be a Spikes, SpikeEpochs, xarray, '
                'DataArray or a pandas DataFrame object.')
         try:
             import xarray as xr
-            if isinstance(cellinfo_source, xr.DataArray):
-                cellinfo = cellinfo_from_xarray(cellinfo_source)
+            if isinstance(inst, xr.DataArray):
+                cellinfo = cellinfo_from_xarray(inst)
             else:
                 raise ValueError(msg)
         except ImportError:

--- a/pylabianca/utils.py
+++ b/pylabianca/utils.py
@@ -645,7 +645,12 @@ def find_cells(inst, not_found='error', **features):
     **features:
         Keyword argument with search criteria. Keys refer to column names in
         the cellinfo dataframe and values are the values to search for.
-        '''
+
+    Returns
+    -------
+    cell_idx: np.ndarray
+        Array of cell indices that match the search criteria.
+    '''
     from numbers import Number
 
     cellinfo = _get_cellinfo(inst)

--- a/pylabianca/viz.py
+++ b/pylabianca/viz.py
@@ -862,7 +862,38 @@ def align_axes_limits(axes=None, ylim=True, xlim=False):
 
 
 # TODO - move this to separate submodule .waveform ?
-def calculate_perceptual_waveform_density(spk, cell_idx):
+# TODO - the API could be better / simplified: low level function that
+#        takes just waveform array and high-level function that takes
+#        Spikes object and cell indices (currently only one cell is supported)
+def calculate_perceptual_waveform_density(spk, cell_idx, take_n=15):
+    """
+    Experimental measure of "perceptual" waveform density.
+
+    The goal is to provide a single value that would reflect the density of
+    the waveform in the similar way we perceive it on waveform density plots.
+
+    The measure is calculated as follows:
+    - calculate 2d histogram of the waveform
+    - correct the y range to remove extreme values that bias the 2d histogram
+      calculation
+    - take the top N values from each row
+    - normalize these values by the maximum value
+    - average the normalized values
+
+    Parameters
+    ----------
+    spk : Spikes | SpikeEpochs
+        Spike object to use.
+    cell_idx : int
+        Index of the cell to calculate the perceptual waveform density for.
+    take_n : int
+        How many top values to take from each row of the 2d histogram.
+
+    Returns
+    -------
+    dns : float
+        Perceptual waveform density.
+    """
     # get waveform 2d histogram image
     hist, _, ybins = (
         _calculate_waveform_density_image(
@@ -902,7 +933,7 @@ def calculate_perceptual_waveform_density(spk, cell_idx):
     # TODO: a better way would be to calculate mean from a spatial window
     #       around max, not the top N values
     hist_sort = np.sort(hist)[:, ::-1]
-    vals = (hist_sort[:, :15] / hist_sort.max()).mean(axis=-1)
+    vals = (hist_sort[:, :take_n] / hist_sort.max()).mean(axis=-1)
     dns = vals.mean()
 
     return dns

--- a/whats_new.md
+++ b/whats_new.md
@@ -10,6 +10,7 @@
 * API: `pylabianca.selectivity.compute_selectivity_continuous()` now returns an `xarray.Dataset` instead of dictionary of `xarray.DataArray` objects. This makes the output more convenient to work with (for example using `.sel()` to select elements of all items at the same time; or ability to use both `['key_name']` and `.key_name` to access items).
 * API: removed, now unnecessary, `ignore_below` argument of `pylabianca.selectivity.depth_of_selectivity()` function. It was used to ignore firing rate values below a certain threshold, but the issue of very small non-zero values was previously fixed (numerical error likely stemming from the fact convolution used fft under the hood).
 * API: removed `min_Hz` argument of `pylabianca.selectivity.compute_selectivity_continuous()`. It was used to ignore average firing rate values below a certain threshold, but such selection should be done by the user before calling the function.
+* API: removed `pylabianca.utils.find_cells_by_cluster_id()` in favor of a more universal `pylabianca.utils.find_cells()`. Instead of doing `pln.utils.find_cells_by_cluster_id([254], channel='A15')` and then `pln.utils.find_cells_by_cluster_id([1854], channel='A23')` one can use `pln.utils.find_cells(cluster=[254, 1854], channel=['A15', 'A23'])`.
 
 <br/>
 


### PR DESCRIPTION
Now, instead of `pln.utils.find_cells_by_cluster_id(...)` one can use `pylabinca.utils.find_cells(cluster=[254, 1854], channel=['A15', 'A23'])`.

### TODOs:
- [x] better coverage of tests
- [ ] add whats new