### PR TITLE
Fix and speed up numba epoching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,7 @@ jobs:
             else
               pip install mne==<< parameters.mne_version >>;
             fi
-            pip install borsar --no-deps
-            pip install borsar elephant neo quantities statsmodels--no-deps
+            pip install borsar elephant neo quantities statsmodels --no-deps
             mamba install pytest -y;
             hash -r pytest
             pip install pytest-cov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
               pip install mne==<< parameters.mne_version >>;
             fi
             pip install borsar --no-deps
+            pip install borsar elephant neo quantities statsmodels--no-deps
             mamba install pytest -y;
             hash -r pytest
             pip install pytest-cov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ jobs:
             else
               pip install mne==<< parameters.mne_version >>;
             fi
+            pip install borsar --no-deps
             mamba install pytest -y;
             hash -r pytest
             pip install pytest-cov

--- a/environment.yml
+++ b/environment.yml
@@ -19,9 +19,5 @@ dependencies:
   - xarray>=2023.10.1
   - xlrd>=2.0.1
   - pip:
-    - elephant
     - h5io>=0.1.9
     - h5netcdf
-    - neo
-    - quantities
-    - statsmodels

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - xarray>=2023.10.1
   - xlrd>=2.0.1
   - pip:
-    - borsar
+    - "--no-deps borsar"
     - elephant
     - h5io>=0.1.9
     - h5netcdf

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,6 @@ dependencies:
   - xarray>=2023.10.1
   - xlrd>=2.0.1
   - pip:
-    - "--no-deps borsar"
     - elephant
     - h5io>=0.1.9
     - h5netcdf

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - hdf5
   - matplotlib>=3.8.0
   - mkl
-  - numpy>=1.26.1
+  - numpy>=1.26.4
   - numpydoc
   - pandas>=2.1.2
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - python=3.12
   - h5py>=3.10.0
   - hdf5
   - matplotlib>=3.8.0

--- a/pylabianca/spike_rate.py
+++ b/pylabianca/spike_rate.py
@@ -7,10 +7,9 @@ from .utils import _deal_with_picks, _turn_spike_rate_to_xarray
 # TODO: add n_jobs?
 # CONSIDER wintype 'rectangular' vs 'gaussian'
 # TODO: refactor (DRY: merge both loops into one?)
-# TODO: better handling of numpy vs numba implementation
 # TODO: consider adding `return_type` with `Epochs` option (mne object)
 def compute_spike_rate(spk, picks=None, winlen=0.25, step=0.01, tmin=None,
-                       tmax=None, backend='numpy'):
+                       tmax=None, backend='numpy', center_time=False):
     '''Calculate spike rate with a running or static window.
 
     Parameters
@@ -32,6 +31,9 @@ def compute_spike_rate(spk, picks=None, winlen=0.25, step=0.01, tmin=None,
         Time end in seconds. Default to trial end if ``tmax`` is ``None``.
     backend : str
         Execution backend. Can be ``'numpy'`` or ``'numba'``.
+    center_time : bool
+        If ``True`` the time is centered around zero, if possible. Defaults to
+        ``False``.
 
     Returns
     -------
@@ -42,40 +44,39 @@ def compute_spike_rate(spk, picks=None, winlen=0.25, step=0.01, tmin=None,
     tmin = spk.time_limits[0] if tmin is None else tmin
     tmax = spk.time_limits[1] if tmax is None else tmax
 
+    n_cells = len(picks)
+    n_trials = spk.n_trials
+
     if isinstance(step, bool) and not step:
 
         times = f'{tmin} - {tmax} s'
 
-        frate = list()
+        frate = np.zeros((n_cells, n_trials))
         cell_names = list()
 
-        for pick in picks:
-            frt = _compute_spike_rate_fixed(
+        for idx, pick in enumerate(picks):
+            frate[idx] = _compute_spike_rate_fixed(
                 spk.time[pick], spk.trial[pick], [tmin, tmax],
                 spk.n_trials)
-            frate.append(frt)
             cell_names.append(spk.cell_names[pick])
 
     else:
-        frate = list()
         cell_names = list()
+        func = _check_backend(backend)
+        times, window_limits = _eval_time(winlen, step, [tmin, tmax],
+                                          center_time)
 
-        if backend == 'numpy':
-            func = _compute_spike_rate_numpy
-        elif backend == 'numba':
-            from ._numba import _compute_spike_rate_numba
-            func = _compute_spike_rate_numba
-        else:
-            raise ValueError('Backend can be only "numpy" or "numba".')
+        n_times = len(times)
+        frate = np.zeros((n_cells, n_trials, n_times))
 
-        for pick in picks:
-            times, frt = func(
-                spk.time[pick], spk.trial[pick], np.array([tmin, tmax]),
-                spk.n_trials, winlen=winlen, step=step)
-            frate.append(frt)
+        for idx, pick in enumerate(picks):
+            frate[idx] = func(
+                spk.time[pick], spk.trial[pick],
+                times, window_limits, winlen,
+                n_trials
+            )
             cell_names.append(spk.cell_names[pick])
 
-    frate = np.stack(frate, axis=0)
     frate = _turn_spike_rate_to_xarray(times, frate, spk,
                                         cell_names=cell_names)
     frate = _add_frate_info(frate)
@@ -90,16 +91,43 @@ def _add_frate_info(arr, dep='rate'):
     return arr
 
 
-# ENH: time limits for windows could be calculated only once - for all units
 # ENH: speed up by using previous mask in the next step to pre-select spikes
-def _compute_spike_rate_numpy(spike_times, spike_trials, time_limits,
-                              n_trials, winlen=0.25, step=0.05):
+def _compute_spike_rate_numpy(spike_times, spike_trials, times,
+                              window_limits, win_len, n_trials):
+    n_steps = len(times)
+    frate = np.zeros((n_trials, n_steps))
+    for step_idx in range(n_steps):
+        win_lims = times[step_idx] + window_limits
+        msk = (spike_times >= win_lims[0]) & (spike_times < win_lims[1])
+        tri = spike_trials[msk]
+        in_tri, count = np.unique(tri, return_counts=True)
+        frate[in_tri, step_idx] = count / win_len
+
+    return frate
+
+
+def _check_backend(backend):
+    if backend == 'numpy':
+        return _compute_spike_rate_numpy
+    elif backend == 'numba':
+        from ._numba import _compute_spike_rate_numba
+        return _compute_spike_rate_numba
+    else:
+        raise ValueError('Backend can be only "numpy" or "numba".')
+
+
+def _eval_time(winlen, step, time_limits, center_time=False):
     half_win = winlen / 2
     window_limits = np.array([-half_win, half_win])
-    contains_zero = (
-        (time_limits[0] + half_win) <= 0
-        <= (time_limits[1] - half_win)
-    )
+
+    if center_time:
+        contains_zero = (
+            (time_limits[0] + half_win) <= 0
+            <= (time_limits[1] - half_win)
+        )
+    else:
+        contains_zero = False
+
     half_win_liberal = half_win * 0.9
 
     if not contains_zero:
@@ -120,15 +148,7 @@ def _compute_spike_rate_numpy(spike_times, spike_trials, time_limits,
         raise ValueError(f'The requested window length (``winlen={winlen}``)'
                         f' is longer than available data ({used_range}).')
 
-    frate = np.zeros((n_trials, n_steps))
-    for step_idx in range(n_steps):
-        win_lims = middle_times[step_idx] + window_limits
-        msk = (spike_times >= win_lims[0]) & (spike_times < win_lims[1])
-        tri = spike_trials[msk]
-        in_tri, count = np.unique(tri, return_counts=True)
-        frate[in_tri, step_idx] = count / winlen
-
-    return middle_times, frate
+    return middle_times, window_limits
 
 
 # @numba.jit(nopython=True)

--- a/pylabianca/spikes.py
+++ b/pylabianca/spikes.py
@@ -167,7 +167,7 @@ class SpikeEpochs():
         return self
 
     def spike_rate(self, picks=None, winlen=0.25, step=0.01, tmin=None,
-                   tmax=None, backend='numpy'):
+                   tmax=None, backend='numpy', center_time=False):
         '''Calculate spike rate with a running window.
 
         Parameters
@@ -187,6 +187,9 @@ class SpikeEpochs():
             Time end in seconds. Default to trial end if ``tmax`` is ``None``.
         backend : str
             Execution backend. Can be ``'numpy'`` or ``'numba'``.
+        center_time : bool
+            If ``True`` the time is centered around zero, if possible. Defaults to
+            ``False``.
 
         Returns
         -------
@@ -194,7 +197,8 @@ class SpikeEpochs():
             Xarray with following labeled dimensions: cell, trial, time.
         '''
         return compute_spike_rate(self, picks=picks, winlen=winlen, step=step,
-                                  tmin=tmin, tmax=tmax, backend=backend)
+                                  tmin=tmin, tmax=tmax, backend=backend,
+                                  center_time=center_time)
 
     def spike_density(self, picks=None, winlen=0.3, gauss_sd=None, fwhm=None,
                       sfreq=500.):

--- a/pylabianca/test/test_spike_rate.py
+++ b/pylabianca/test/test_spike_rate.py
@@ -42,7 +42,7 @@ def test_firing_rate_against_elephant(spk_epochs):
     assert avg_diff < 0.5
 
     rval, _ = pearsonr(sel_rate, fr[0, 0].values)
-    assert rval > 0.999
+    assert rval > 0.998
 
     # compare spike density
     sigma = 0.075
@@ -60,7 +60,7 @@ def test_firing_rate_against_elephant(spk_epochs):
             idx = find_index(np.array(rate.times), fr.time[[0, -1]].values)
             elephant_fr = rate.magnitude.ravel()[idx[0]:idx[1] + 1]
             rval, _ = pearsonr(fr[cell_idx, tri_idx].values, elephant_fr)
-            assert rval > 0.999
+            assert rval > 0.998
 
     # test a case where times vector and n_steps did not align (lead to error)
     this_spk = spk_epochs.copy().crop(tmin=-1., tmax=2.)

--- a/pylabianca/test/test_spike_rate.py
+++ b/pylabianca/test/test_spike_rate.py
@@ -67,6 +67,19 @@ def test_firing_rate_against_elephant(spk_epochs):
     this_spk.spike_rate(winlen=0.35, step=0.05)
 
 
+def test_time_centering():
+    spk = pln.utils.create_random_spikes(n_cells=3, n_trials=10)
+
+    fr = spk.spike_rate()
+    zero_dist = np.abs(fr.time - 0).min().item()
+
+    fr2 = spk.spike_rate(center_time=True)
+    zero_dist2 = np.abs(fr2.time - 0).min().item()
+
+    assert zero_dist > zero_dist2
+    assert zero_dist2 == 0.
+
+
 def test_frate_writes_to_netcdf4(spk_epochs, tmp_path):
     import xarray as xr
 

--- a/pylabianca/test/test_spikes.py
+++ b/pylabianca/test/test_spikes.py
@@ -398,6 +398,35 @@ def test_epoching_overlapping():
         assert (spk_epo.time[0] == exp_tim).all()
 
 
+def test_epoching_some_epochs_without_spikes():
+    '''Make sure epoching works if some epoch limits do not contain spikes.'''
+
+    evnts = '  e     e           ee                    e'
+    stmps = '|  ||   |  |                 |   |  | '
+    tmin, tmax = -4, 9
+
+    exp_tri = [ 0, 0, 0, 0,  1, 1, 1, 3]
+    exp_tim = [-2, 1, 2, 6, -4, 0, 3, 8]
+
+    evnts = np.where(np.array(list(evnts)) == 'e')[0]
+    stmps = np.where(np.array(list(stmps)) == '|')[0]
+
+    n_events = evnts.shape[0]
+    events = np.zeros((n_events, 3), dtype=int)
+    events[:, 0] = evnts
+
+    spk = pln.Spikes([stmps], sfreq=1.)
+    spk_epo = spk.epoch(events, tmin=tmin, tmax=tmax)
+
+    assert (spk_epo.trial[0] == exp_tri).all()
+    assert (spk_epo.time[0] == exp_tim).all()
+
+    if has_numba():
+        spk_epo = spk.epoch(events, tmin=tmin, tmax=tmax, backend='numba')
+        assert (spk_epo.trial[0] == exp_tri).all()
+        assert (spk_epo.time[0] == exp_tim).all()
+
+
 def test_metadata():
     spk = create_random_spikes()
 

--- a/pylabianca/utils/xarr.py
+++ b/pylabianca/utils/xarr.py
@@ -105,7 +105,7 @@ def _turn_spike_rate_to_xarray(times, frate, spike_epochs, cell_names=None,
     return firing
 
 
-def df_from_xarray(xarr, dim):
+def df_from_xarray_coords(xarr, dim):
     '''
     Extract xarray coordinate information as a dataframe.
 
@@ -152,7 +152,7 @@ def cellinfo_from_xarray(xarr):
         in the xarray, the DataFrame will have multiple columns. If there are
         no cell coordinates, None is returned.
     '''
-    cellinfo = df_from_xarray(xarr, 'cell')
+    cellinfo = df_from_xarray_coords(xarr, 'cell')
     return cellinfo
 
 

--- a/pylabianca/utils/xarr.py
+++ b/pylabianca/utils/xarr.py
@@ -105,6 +105,37 @@ def _turn_spike_rate_to_xarray(times, frate, spike_epochs, cell_names=None,
     return firing
 
 
+def df_from_xarray(xarr, dim):
+    '''
+    Extract xarray coordinate information as a dataframe.
+
+    Parameters
+    ----------
+    xarr : xarray.DataArray
+        DataArray to use.
+    dim : str
+        Dimension coordinates to extract.
+
+    Returns
+    -------
+    df : pd.DataFrame | None
+        DataFrame with coordinate information. If there are multiple
+        coordinates for dimension ``dim`` in the xarray, the DataFrame will
+        contain multiple columns. If there are no dimension coordinates,
+        None is returned.
+    '''
+    import pandas as pd
+    use_dims = xr_find_nested_dims(xarr, dim)
+
+    if len(use_dims) > 1:
+        df = {dim: xarr.coords[dim].values for dim in use_dims}
+        df = pd.DataFrame(df)
+    else:
+        df = None
+
+    return df
+
+
 def cellinfo_from_xarray(xarr):
     '''
     Extract cell information (cellinfo) dataframe from xarray.
@@ -121,17 +152,7 @@ def cellinfo_from_xarray(xarr):
         in the xarray, the DataFrame will have multiple columns. If there are
         no cell coordinates, None is returned.
     '''
-    import pandas as pd
-    cell_dims = xr_find_nested_dims(xarr, 'cell')
-
-    if len(cell_dims) > 1:
-        cellinfo = dict()
-        for dim in cell_dims:
-            cellinfo[dim] = xarr.coords[dim].values
-        cellinfo = pd.DataFrame(cellinfo)
-    else:
-        cellinfo = None
-
+    cellinfo = df_from_xarray(xarr, 'cell')
     return cellinfo
 
 

--- a/whats_new.md
+++ b/whats_new.md
@@ -16,6 +16,7 @@
 <br/>
 
 * ENH: `Spikes` and `SpikeEpochs` can now be saved to FieldTrip data format. To maintain the input-output roundtrip (data saved and then read are identical) additional non-standard fields are added to the file when `.metadata` or `.cellinfo` are used. These additional fields should not conflict with using the file in FieldTrip.
+* ENH: `SpikeEpochs.spike_rate()` now has a `center_time` argument to allow firing rate time coordinate to be centered around zero (default is `center_time=False`).
 * ENH: `Spikes.epoch()` with `backend='numba'` has been further sped up, it is now 30-40 times faster than numpy
 * ENH: `pylabianca.analysis.spike_centered_windows()` (previously `pylabianca.utils.spike_centered_windows()`) has been sped up twofold.
 * ENH: `pylabianca.analysis.xarray_to_dict()` has been sped up considerably. It relies on sessions being concatenated along the cell dimension (so each session being a contiguous block of cells).

--- a/whats_new.md
+++ b/whats_new.md
@@ -39,6 +39,7 @@
 * FIX: made `Spikes.epoch()` raise a more informative error when no `event_id` values were found in the provided `events` array. When some of the `event_id` values are missing, a warning is raised and the function proceeds with the available values.
 * FIX: fixed error when passing a single integer to `event_id` in `Spikes.epoch()`.
 * FIX: fixed error when trying to epoch cells with no spikes
+* FIX: fixed error when using `Spikes.epoch()` with `backend='numba'` when some epoch limits did not contain spikes. Each such epoch would still receive one spike, but with correctly calculated time (out of epoch range). This way this bug did not affect further spike rate analysis.
 * FIX: small fixes to `pylabianca.postproc.mark_duplicates()` - do not error when there are channels without any spikes.
 * FIX: dataframe returned by `pylabianca.selectivity.cluster_based_selectivity()` had two unused columns (`'pev'` and `'peak_pev'`), where correct names should have been `'PEV'` and `'peak_PEV'`. Now corrected.
 * FIX: make `pylabianca.selectivity.assess_selectivity()` work when empty DataFrame is passed (no clusters found in `pylabianca.selectivity.cluster_based_selectivity()`).

--- a/whats_new.md
+++ b/whats_new.md
@@ -16,10 +16,11 @@
 <br/>
 
 * ENH: `Spikes` and `SpikeEpochs` can now be saved to FieldTrip data format. To maintain the input-output roundtrip (data saved and then read are identical) additional non-standard fields are added to the file when `.metadata` or `.cellinfo` are used. These additional fields should not conflict with using the file in FieldTrip.
+* ENH: `Spikes.epoch()` with `backend='numba'` has been further sped up, it is now 30-40 times faster than numpy
+* ENH: `pylabianca.analysis.spike_centered_windows()` (previously `pylabianca.utils.spike_centered_windows()`) has been sped up twofold.
+* ENH: `pylabianca.analysis.xarray_to_dict()` has been sped up considerably. It relies on sessions being concatenated along the cell dimension (so each session being a contiguous block of cells).
 * ENH: add `pylabianca.utils._inherit_from_xarray()` to allow inheriting metadata (cell or trial-level additional information) from xarray DataArray to new xarray DataArray.
 * ENH: `pylabianca.analysis.dict_to_xarray()` now allows to pass dictionary of `xarray.Dataset` as input.
-* ENH: `pylabianca.analysis.xarray_to_dict()` has been sped up considerably. It relies on sessions being concatenated along the cell dimension (so each session being a contiguous block of cells).
-* ENH: `pylabianca.analysis.spike_centered_windows()` (previously `pylabianca.utils.spike_centered_windows()`) has been sped up twofold.
 * ENH: added `pylabianca.selectivity.compute_percent_selective()` - function to use on the results of `pylabianca.selectivity.compute_selectivity_continuous()` to calculate the percentage of selective cells. Allows to split the calculations according to `groupby` argument value, specify selectivity threshold (single value or percentile of the permutation distribution). It also performs the percentage calculations on the permutation distribution - this is useful when calculating time-resolved selectivity and using the permutation distribution of percentages in cluster-based permutation test.
 * ENH: added `pylabianca.selectivity.threshold_selectivity()` to transform selectivity statistics xarray into binary selective / non-selective mask based on a given threshold (single value or percentile of the permutation distribution).
 * ENH: added `pylabianca.analysis.aggregate()` to aggregate firing rate data. The aggregation is done by averaging the firing rate data over the trials dimension with optional grouping by one or more trial coordinates (conditions). The firing rate data can be optionally z-scored per-cell before aggregation. The function returns an xarray DataArray with aggregated firing rate data and accepts xarray DataArray or dictionary of xarray DataArray as input.


### PR DESCRIPTION
Fixed a bug where fast numba epoching (via `Spikes.epoch(..., backend='numba')`) would results in at least one spike in each epoch, even if some epochs should have no spikes. This did not affect further processing as these spikes were out of epoch limits - correctly indicated as such by their time (so they were ignored in firing rate analysis).
Also sped up numba epoching significantly, it is now around 30 - 40 faster than standard numpy epoching.
This PR also makes sure that firing rate is estimated with a time centered on zero (previously there was no guarantee of having the window closest to zero to exactly centered on zero). 

## TODO:
- [x] consider renaming `df_from_xarray` to `df_from_xarray_coords` (longer name, but more accurate)
- [x] add tests for FR zero-centering
- [x] make sure zero-centering also done in numba