### PR TITLE
FIX: fix numba epoching when no spikes

### DIFF
--- a/pylabianca/_numba.py
+++ b/pylabianca/_numba.py
@@ -244,12 +244,19 @@ def _epoch_spikes_numba(spike_times, event_times, event_tmin, event_tmax,
     epoch_spike_times = []
 
     num_spikes = len(spike_times)
+
+    if num_spikes == 0:
+        return np.array(trial_ids), np.array(epoch_spike_times)
+
     start_idx = 0
     current_idx = 0
-    step_multiplier = max(1, int(np.round(
-        num_spikes / (spike_times[-1] - spike_times[0])
-        )))
+    time_range = max(1, spike_times[-1] - spike_times[0])
     epoch_len = event_tmax[0] - event_tmin[0]
+
+    step_multiplier = max(1, int(
+        np.round(num_spikes / time_range)
+        )
+    )
 
     for trial_idx, event_time in enumerate(event_times):
         start_time = event_tmin[trial_idx]


### PR DESCRIPTION
The numba implementation of epoching did not consider case when there are no spikes for given neuron (this can happen after epoching to rarely firing cells - the considered epochs do not contain any of the spikes the cell produced during the recording).

TODO:
- [ ] add test for 0, 1 and 2 spikes