### PR TITLE
FIX: utils.find_cells using cell coordinate

### DIFF
--- a/pylabianca/utils/xarr.py
+++ b/pylabianca/utils/xarr.py
@@ -126,6 +126,8 @@ def df_from_xarray_coords(xarr, dim):
     '''
     import pandas as pd
     use_dims = find_nested_dims(xarr, dim)
+    if dim not in use_dims:
+        use_dims = [dim] + use_dims
 
     if len(use_dims) > 1:
         df = {dim: xarr.coords[dim].values for dim in use_dims}


### PR DESCRIPTION
When using `pylabianca.utils.find_cells` it may seem intuitive to use cell name as here, assuming we have a frate xarray:
```python
import pylabianca as pln

pln.utils.find_cells(frate, cell=['cell001', 'cell002', 'cell012'])
```
but this will currently fail, even when, as expected, frate contains a `'cell'` coordinate. This is because, when creating a pandas.DataFrame cellinfo out of xarray.DataArray frates, the cell dimention is not added. This PR aims to solve it while not breaking other things. This will probabaly require adding a keyword arg to function creating a dataframe from xarray dimention coordinates.