### PR TITLE
Skip cells with no spikes when calculating firing rate

### DIFF
--- a/pylabianca/spike_rate.py
+++ b/pylabianca/spike_rate.py
@@ -124,6 +124,10 @@ def _eval_time(winlen, step, time_limits, center_time=False):
     half_win = winlen / 2
     window_limits = np.array([-half_win, half_win])
 
+    if np.isnan(time_limits[0]) or np.isnan(time_limits[1]):
+        middle_times = np.array([])
+        return middle_times, window_limits
+
     if center_time:
         contains_zero = (
             (time_limits[0] + half_win) <= 0

--- a/pylabianca/spike_rate.py
+++ b/pylabianca/spike_rate.py
@@ -55,9 +55,11 @@ def compute_spike_rate(spk, picks=None, winlen=0.25, step=0.01, tmin=None,
         cell_names = list()
 
         for idx, pick in enumerate(picks):
-            frate[idx] = _compute_spike_rate_fixed(
-                spk.time[pick], spk.trial[pick], [tmin, tmax],
-                spk.n_trials)
+            spk_times = spk.time[pick]
+            if len(spk_times) > 0:
+                frate[idx] = _compute_spike_rate_fixed(
+                    spk_times, spk.trial[pick], [tmin, tmax],
+                    spk.n_trials)
             cell_names.append(spk.cell_names[pick])
 
     else:
@@ -70,11 +72,13 @@ def compute_spike_rate(spk, picks=None, winlen=0.25, step=0.01, tmin=None,
         frate = np.zeros((n_cells, n_trials, n_times))
 
         for idx, pick in enumerate(picks):
-            frate[idx] = func(
-                spk.time[pick], spk.trial[pick],
-                times, window_limits, winlen,
-                n_trials
-            )
+            spk_times = spk.time[pick]
+            if len(spk_times) > 0:
+                frate[idx] = func(
+                    spk_times, spk.trial[pick],
+                    times, window_limits, winlen,
+                    n_trials
+                )
             cell_names.append(spk.cell_names[pick])
 
     frate = _turn_spike_rate_to_xarray(times, frate, spk,

--- a/pylabianca/spikes.py
+++ b/pylabianca/spikes.py
@@ -716,14 +716,21 @@ def _spikes_to_raw(spk, picks=None, sfreq=500.):
         ``trials x cells x time samples`` array with binary spike information.
     '''
     picks = _deal_with_picks(spk, picks)
+    n_cells = len(picks)
+
+    tmin, tmax = spk.time_limits
+
+    if np.isnan(tmin) or np.isnan(tmax):
+        times = np.array([])
+        trials_raw = np.zeros((spk.n_trials, n_cells, 0), dtype='int')
+        return times, trials_raw
+
     sample_time = 1 / sfreq
     half_sample = sample_time / 2
-    tmin, tmax = spk.time_limits
     times = np.arange(tmin, tmax + 0.01 * sample_time, step=sample_time)
     time_bins = np.concatenate(
         [times - half_sample, [times[-1] + half_sample]])
 
-    n_cells = len(picks)
     n_times = len(times)
     trials_raw = np.zeros((spk.n_trials, n_cells, n_times), dtype='int')
 

--- a/pylabianca/spikes.py
+++ b/pylabianca/spikes.py
@@ -66,8 +66,10 @@ class SpikeEpochs():
         self.trial = trial
 
         if time_limits is None:
-            tmin = min([min(x) for x in time if len(x) > 0])
-            tmax = max([max(x) for x in time if len(x) > 0]) + 1e-6
+            mins = [min(x) for x in time if len(x) > 0]
+            maxs = [max(x) for x in time if len(x) > 0]
+            tmin = min(mins) if len(mins) > 0 else np.nan
+            tmax = max(maxs) + 1e-6 if len(maxs) > 0 else np.nan
             time_limits = np.array([tmin, tmax])
         self.time_limits = time_limits
 

--- a/pylabianca/test/test_spike_rate.py
+++ b/pylabianca/test/test_spike_rate.py
@@ -105,8 +105,8 @@ def test_frate_no_spikes():
 
     assert fr.shape == (1, 0, 0)
 
-    msg = (r"Convolution kernel length (151 samples) exceeds the length of "
-           r"the data (0 samples).")
+    msg = (r"Convolution kernel length \(151 samples\) exceeds the length of "
+           r"the data \(0 samples\).")
     with pytest.raises(ValueError, match=msg):
         spk.spike_density()
 

--- a/pylabianca/test/test_spike_rate.py
+++ b/pylabianca/test/test_spike_rate.py
@@ -91,3 +91,33 @@ def test_frate_writes_to_netcdf4(spk_epochs, tmp_path):
     fr2 = xr.load_dataarray(fpath)
 
     assert fr.equals(fr2)
+
+
+def test_frate_no_spikes():
+    # test 01 - 1 cell with 0 spikes
+    # ------------------------------
+    spk = pln.SpikeEpochs([np.array([])], [np.array([])])
+
+    # compute firing rate
+    # BUT: could in future raise similar error (or warning) than spk.spike_denisty
+    #      as there is not enough time points for one FR step ...
+    fr = spk.spike_rate()
+
+    assert fr.shape == (1, 0, 0)
+
+    msg = (r"Convolution kernel length (151 samples) exceeds the length of "
+           r"the data (0 samples).")
+    with pytest.raises(ValueError, match=msg):
+        spk.spike_density()
+
+    # test 02 - 2 cells, one with spikes, one without
+    # -----------------------------------------------
+    tri = np.array([0, 0, 0, 1, 1, 2])
+    tim = np.array([-0.1, 0.8, 1.1, 0.2, 0.6, -0.3])
+    spk = pln.SpikeEpochs([tim, np.array([])], [tri, np.array([])])
+
+    fr = spk.spike_rate()
+    assert fr.shape == (2, 3, 117)
+
+    fd = spk.spike_density()
+    assert fd.shape == (2, 3, 551)

--- a/pylabianca/test/test_viz.py
+++ b/pylabianca/test/test_viz.py
@@ -9,6 +9,12 @@ import pylabianca as pln
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def close_figures():
+    yield
+    plt.close('all')
+
+
 def test_plot_shaded():
     # create random xarray
     # cell x trial x time

--- a/pylabianca/utils/xarr.py
+++ b/pylabianca/utils/xarr.py
@@ -55,18 +55,24 @@ def _turn_spike_rate_to_xarray(times, frate, spike_epochs, cell_names=None,
 
     # later: consider having firing rate from many neurons...
     times_array = isinstance(times, np.ndarray)
+    has_trials = False
     if frate.ndim == 3:
+        has_trials = True
+        # CHECK: if data is 3D can cell_names be really None?
         n_trials = frate.shape[0] if cell_names is None else frate.shape[1]
     elif frate.ndim == 2:
         if cell_names is None:
+            has_trials = True
             n_trials = frate.shape[0]
         else:
             if times_array:
+                has_trials = False
                 n_trials = 0
             else:
+                has_trials = True
                 n_trials = frate.shape[1]
 
-    if n_trials > 0:
+    if has_trials:
         dimname = 'trial' if tri is None else 'spike'
         coords = {dimname: np.arange(n_trials)}
         dims = [dimname]
@@ -75,7 +81,7 @@ def _turn_spike_rate_to_xarray(times, frate, spike_epochs, cell_names=None,
         dims = list()
 
     attrs = None
-    if isinstance(times, np.ndarray):
+    if times_array:
         dims.append(x_dim_name)
         coords[x_dim_name] = times
     else:


### PR DESCRIPTION
* Skip cells with no spikes when calculating firing rate. Previously such cells would have to be dropped before calculating firing rate, but it does not seem necessary.
* also allows creating of SpikeEpochs where all cells have no spikes (previously this would lead to error when auto-computing epoch time ranges)