### PR TITLE
FIX: spk.crop()

### DIFF
--- a/pylabianca/spikes.py
+++ b/pylabianca/spikes.py
@@ -149,9 +149,9 @@ class SpikeEpochs():
         if tmin is None and tmax is None:
             raise TypeError('You have to specify tmin and/or tmax.')
 
-        if tmin is None:
+        if tmin is None or tmin < self.time_limits[0]:
             tmin = self.time_limits[0]
-        if tmax is None:
+        if tmax is None or tmax > self.time_limits[1]:
             tmax = self.time_limits[1]
 
         has_waveform = self.waveform is not None

--- a/pylabianca/test/test_spikes.py
+++ b/pylabianca/test/test_spikes.py
@@ -143,6 +143,18 @@ def test_crop():
         spk_orig.copy().crop(tmin=None, tmax=None)
 
 
+def test_crop_does_not_extend():
+    spk = create_random_spikes(n_cells=1, n_trials=10)
+    limits = spk.time_limits
+
+    spk2 = spk.copy()
+    spk2.crop(tmin=limits[0] - 1, tmax=limits[1] + 1)
+    limits2 = spk2.time_limits
+
+    assert limits[0] == limits2[0]
+    assert limits[1] == limits2[1]
+
+
 # add .n_trials (if present in SpikeEpochs)
 def test_num():
     for n_cells in [3, 5, 10]:


### PR DESCRIPTION
do not extend time_limits if tmin/tmax given to .crop() is out o…f range