### PR TITLE
Fix cluster_based_test returning Clusters object

### DIFF
--- a/pylabianca/stats.py
+++ b/pylabianca/stats.py
@@ -143,12 +143,14 @@ def cluster_based_test(frate, compare='image', cluster_entry_pval=0.05,
 
     Returns
     -------
-    stats : numpy.ndarray
-        Anova F statistics for every time point.
+    stats : numpy.ndarray | borsar.Clusters
+        Value of the test statistic for every time point. If
+        ``return_clusters=True``, then a ``borsar.Clusters`` object is
+        returned instead.
     clusters : list of numpy.ndarray
-        List of cluster memberships.
+        List of cluster memberships. Only returned if ``return_clusters=False``.
     pval : numpy.ndarray
-        List of p values from anova.
+        List of p values from anova. Only returned if ``return_clusters=False``.
     '''
     from borsar.cluster import permutation_cluster_test_array
 

--- a/pylabianca/stats.py
+++ b/pylabianca/stats.py
@@ -176,7 +176,8 @@ def cluster_based_test(frate, compare='image', cluster_entry_pval=0.05,
     if return_clusters:
         from borsar.cluster.obj import Clusters
 
-        dimnames, dimcoords = _infer_cluster_coords(frate, compare)
+        dimnames, dimcoords, stat, clusters = _infer_cluster_coords(
+            frate, compare, stat, clusters)
         return Clusters(stat, clusters=clusters, pvals=pval,
                         dimnames=dimnames, dimcoords=dimcoords)
 
@@ -186,24 +187,34 @@ def cluster_based_test(frate, compare='image', cluster_entry_pval=0.05,
 # TODO: this might later need checking against other xarray helpers
 #       to de-duplicate (and some code present in selectivity module
 #       for xarray construction!)
-def _infer_cluster_coords(xarr, compare):
+def _infer_cluster_coords(xarr, compare, stat, clusters):
     dimnames = None
+    drop_dims = list()
 
-    # infer reduced dimension from compare coordinate / dimension
+    # infer reduced dimensions from compare coordinate / dimension
     if compare in xarr.coords:
         compare_dims = xarr.coords[compare].dims
         assert len(compare_dims) == 1
-        compare = compare_dims[0]
+        drop_dims.append(compare)
+
+    # first dimension (observations) should be reduces
+    drop_dims.append(xarr.dims[0])
 
     n_orig_dims = len(xarr.dims)
-    dimnames = [dim for dim in xarr.dims if dim != compare]
+    dimnames = [dim for dim in xarr.dims if dim not in drop_dims]
 
     if len(dimnames) == n_orig_dims:
         raise RuntimeError('Could not find the reduced dimension.')
 
+    # drop singleton dimentions from stat, if not present in xarr
+    ndim_diff = stat.ndim - len(dimnames)
+    if ndim_diff > 0:
+        stat = np.squeeze(stat)
+        clusters = [np.squeeze(c) for c in clusters]
+
     coords = [xarr.coords[dim_name].values for dim_name in dimnames]
 
-    return dimnames, coords
+    return dimnames, coords, stat, clusters
 
 
 # ENH: move to sarna/borsar sometime

--- a/pylabianca/stats.py
+++ b/pylabianca/stats.py
@@ -163,7 +163,11 @@ def cluster_based_test(frate, compare='image', cluster_entry_pval=0.05,
                       FutureWarning)
 
     # TODO: check if theres is a condition dimension (if so -> paired)
-    arrays = [arr.values for _, arr in frate.groupby(compare)]
+    # TODO: better check for reduced dimention name
+    reduced_dim = frate.coords[compare].dims[0]
+    dim_idx = frate.dims.index(reduced_dim)
+    arrays = [np.squeeze(arr.values, axis=dim_idx)
+              for _, arr in frate.groupby(compare)]
 
     if tail is None:
         n_groups = len(arrays)

--- a/pylabianca/stats.py
+++ b/pylabianca/stats.py
@@ -178,8 +178,10 @@ def cluster_based_test(frate, compare='image', cluster_entry_pval=0.05,
     if return_clusters:
         from borsar.cluster.obj import Clusters
         dimcoords = [frate.coords[dimname].values for dimname in dimnames]
-        desc = {'n_permutations': n_permutations, 'compare': compare,
-                'levels': levels}
+        desc = { 'compare': compare, 'levels': levels, 'paired': paired,
+                'tail': tail, 'n_permutations': n_permutations,
+                'n_stat_permutations': n_stat_permutations,
+                'cluster_entry_p_threshold': cluster_entry_pval}
         return Clusters(
             stat, clusters=clusters, pvals=pval,
             dimnames=dimnames, dimcoords=dimcoords, description=desc

--- a/pylabianca/stats.py
+++ b/pylabianca/stats.py
@@ -108,7 +108,9 @@ def permutation_test(*arrays, paired=False, n_perm=1_000, progress=False,
         else:
             return stat
 
-
+# TODO: looking for reduced dimentions, transposing, etc. should be checked
+#       against other xarray helpers to de-duplicate (some code present in
+#       selectivity module for xarray construction!)
 # TODO: auto-infer paired from xarray
 def cluster_based_test(frate, compare='image', cluster_entry_pval=0.05,
                        paired=False, stat_fun=None, n_permutations=1_000,
@@ -163,11 +165,34 @@ def cluster_based_test(frate, compare='image', cluster_entry_pval=0.05,
                       FutureWarning)
 
     # TODO: check if theres is a condition dimension (if so -> paired)
-    # TODO: better check for reduced dimention name
-    reduced_dim = frate.coords[compare].dims[0]
-    dim_idx = frate.dims.index(reduced_dim)
-    arrays = [np.squeeze(arr.values, axis=dim_idx)
-              for _, arr in frate.groupby(compare)]
+    arrays = [arr.values for _, arr in frate.groupby(compare)]
+
+    # prepare arrays for analysis
+    drop_dims = list()
+    if compare in frate.dims:
+        drop_dims.append(compare)
+        dim_idx = frate.dims.index(compare)
+        arrays = [np.squeeze(arr, axis=dim_idx) for arr in arrays]
+
+        # first dimension (observations) should be reduced
+        # TODO: auto-detect observation dimension and make sure it is first
+        first_dim = 0 + int(dim_idx == 0)
+        drop_dims.append(frate.dims[first_dim])
+    elif compare in frate.coords:
+        reduced_dim = frate.coords[compare].dims
+        assert len(reduced_dim) == 1
+        reduced_dim = reduced_dim[0]
+        reduced_dim_idx = frate.dims.index(reduced_dim)
+        drop_dims.append(reduced_dim)
+
+        if not reduced_dim_idx == 0:
+            dim_ord = np.arange(arrays[0].ndim)
+            dim_ord = np.delete(dim_ord, reduced_dim_idx)
+            dim_ord = np.concatenate([[reduced_dim_idx], dim_ord])
+            arrays = [arr.transpose(*dim_ord) for arr in arrays]
+    else:
+        raise ValueError('Dimension to test (``compare``) was not found in'
+                         ' the provided DataArray.')
 
     if tail is None:
         n_groups = len(arrays)

--- a/pylabianca/stats.py
+++ b/pylabianca/stats.py
@@ -207,45 +207,13 @@ def cluster_based_test(frate, compare='image', cluster_entry_pval=0.05,
     if return_clusters:
         from borsar.cluster.obj import Clusters
 
-        dimnames, dimcoords, stat, clusters = _infer_cluster_coords(
-            frate, compare, stat, clusters)
+        dimnames = [dimname for dimname in frate.dims
+                    if dimname not in drop_dims]
+        dimcoords = [frate.coords[dimname].values for dimname in dimnames]
         return Clusters(stat, clusters=clusters, pvals=pval,
                         dimnames=dimnames, dimcoords=dimcoords)
 
     return stat, clusters, pval
-
-
-# TODO: this might later need checking against other xarray helpers
-#       to de-duplicate (and some code present in selectivity module
-#       for xarray construction!)
-def _infer_cluster_coords(xarr, compare, stat, clusters):
-    dimnames = None
-    drop_dims = list()
-
-    # infer reduced dimensions from compare coordinate / dimension
-    if compare in xarr.coords:
-        compare_dims = xarr.coords[compare].dims
-        assert len(compare_dims) == 1
-        drop_dims.append(compare)
-
-    # first dimension (observations) should be reduces
-    drop_dims.append(xarr.dims[0])
-
-    n_orig_dims = len(xarr.dims)
-    dimnames = [dim for dim in xarr.dims if dim not in drop_dims]
-
-    if len(dimnames) == n_orig_dims:
-        raise RuntimeError('Could not find the reduced dimension.')
-
-    # drop singleton dimentions from stat, if not present in xarr
-    ndim_diff = stat.ndim - len(dimnames)
-    if ndim_diff > 0:
-        stat = np.squeeze(stat)
-        clusters = [np.squeeze(c) for c in clusters]
-
-    coords = [xarr.coords[dim_name].values for dim_name in dimnames]
-
-    return dimnames, coords, stat, clusters
 
 
 # ENH: move to sarna/borsar sometime

--- a/pylabianca/stats.py
+++ b/pylabianca/stats.py
@@ -108,12 +108,9 @@ def permutation_test(*arrays, paired=False, n_perm=1_000, progress=False,
         else:
             return stat
 
-# TODO: looking for reduced dimentions, transposing, etc. should be checked
-#       against other xarray helpers to de-duplicate (some code present in
-#       selectivity module for xarray construction!)
-# TODO: auto-infer paired from xarray
+
 def cluster_based_test(frate, compare='image', cluster_entry_pval=0.05,
-                       paired=False, stat_fun=None, n_permutations=1_000,
+                       paired=None, stat_fun=None, n_permutations=1_000,
                        n_stat_permutations=0, tail=None, progress=True,
                        return_clusters=None):
     '''Perform cluster-based tests on firing rate data.
@@ -137,8 +134,10 @@ def cluster_based_test(frate, compare='image', cluster_entry_pval=0.05,
         categories to test selectivity for.
     cluster_entry_pval : float
         p value used as a cluster-entry threshold. The default is ``0.05``.
-    paired : bool
+    paired : bool | None
         Whether a paired (repeated measures) or unpaired test should be used.
+        Defaults to ``None`` which infers the type of test from the structure
+        of the DataArray.
     return_clusters : bool
         Whether to return a ``borsar.Clusters`` object instead of a
         ``(stat, clusters, pval)`` tuple.
@@ -164,35 +163,7 @@ def cluster_based_test(frate, compare='image', cluster_entry_pval=0.05,
                       ' old behavior use `return_clusters=False`.',
                       FutureWarning)
 
-    # TODO: check if theres is a condition dimension (if so -> paired)
-    arrays = [arr.values for _, arr in frate.groupby(compare)]
-
-    # prepare arrays for analysis
-    drop_dims = list()
-    if compare in frate.dims:
-        drop_dims.append(compare)
-        dim_idx = frate.dims.index(compare)
-        arrays = [np.squeeze(arr, axis=dim_idx) for arr in arrays]
-
-        # first dimension (observations) should be reduced
-        # TODO: auto-detect observation dimension and make sure it is first
-        first_dim = 0 + int(dim_idx == 0)
-        drop_dims.append(frate.dims[first_dim])
-    elif compare in frate.coords:
-        reduced_dim = frate.coords[compare].dims
-        assert len(reduced_dim) == 1
-        reduced_dim = reduced_dim[0]
-        reduced_dim_idx = frate.dims.index(reduced_dim)
-        drop_dims.append(reduced_dim)
-
-        if not reduced_dim_idx == 0:
-            dim_ord = np.arange(arrays[0].ndim)
-            dim_ord = np.delete(dim_ord, reduced_dim_idx)
-            dim_ord = np.concatenate([[reduced_dim_idx], dim_ord])
-            arrays = [arr.transpose(*dim_ord) for arr in arrays]
-    else:
-        raise ValueError('Dimension to test (``compare``) was not found in'
-                         ' the provided DataArray.')
+    arrays, levels, dimnames, paired = _prepare_arrays(frate, compare, paired)
 
     if tail is None:
         n_groups = len(arrays)
@@ -206,14 +177,70 @@ def cluster_based_test(frate, compare='image', cluster_entry_pval=0.05,
 
     if return_clusters:
         from borsar.cluster.obj import Clusters
-
-        dimnames = [dimname for dimname in frate.dims
-                    if dimname not in drop_dims]
         dimcoords = [frate.coords[dimname].values for dimname in dimnames]
-        return Clusters(stat, clusters=clusters, pvals=pval,
-                        dimnames=dimnames, dimcoords=dimcoords)
+        desc = {'n_permutations': n_permutations, 'compare': compare,
+                'levels': levels}
+        return Clusters(
+            stat, clusters=clusters, pvals=pval,
+            dimnames=dimnames, dimcoords=dimcoords, description=desc
+        )
 
     return stat, clusters, pval
+
+
+# TODO: looking for reduced dimensions, transposing, etc. should be checked
+#       against other xarray helpers to de-duplicate (some code present in
+#       selectivity module for xarray construction!)
+def _prepare_arrays(frate, compare, paired):
+    '''Extract and convert arrays format expected by the cluster based test.
+
+    Additionally: a) returns inferred dimnames for the stats array after
+    conducting the test and b) auto-detects if paired test should be conducted
+    based on the DataArray structure.'''
+
+    if compare not in frate.coords:
+        raise ValueError(f'``compare`` ("{compare}") was not found in'
+                         ' the provided DataArray coordinates.')
+
+    # extract the arrays grouped by the comapre condition
+    arrays, levels = list(), list()
+    for lvl, arr in frate.groupby(compare):
+        arrays.append(arr.values)
+        levels.append(lvl)
+
+    # prepare arrays for analysis
+    drop_dims = list()
+    if compare in frate.dims:
+        drop_dims.append(compare)
+        dim_idx = frate.dims.index(compare)
+        arrays = [np.squeeze(arr, axis=dim_idx) for arr in arrays]
+
+        # first dimension (observations) should be reduced
+        # TODO: auto-detect observation dimension and make sure it is first
+        first_dim = 0 + int(dim_idx == 0)
+        drop_dims.append(frate.dims[first_dim])
+
+        if paired is None:
+            paired = True
+    else:
+        reduced_dim = frate.coords[compare].dims
+        assert len(reduced_dim) == 1
+        reduced_dim = reduced_dim[0]
+        reduced_dim_idx = frate.dims.index(reduced_dim)
+        drop_dims.append(reduced_dim)
+
+        if not reduced_dim_idx == 0:
+            dim_ord = np.arange(arrays[0].ndim)
+            dim_ord = np.delete(dim_ord, reduced_dim_idx)
+            dim_ord = np.concatenate([[reduced_dim_idx], dim_ord])
+            arrays = [arr.transpose(*dim_ord) for arr in arrays]
+
+        if paired is None:
+            paired = False
+
+    dimnames = [dimname for dimname in frate.dims
+                if dimname not in drop_dims]
+    return arrays, levels, dimnames, paired
 
 
 # ENH: move to sarna/borsar sometime

--- a/pylabianca/stats.py
+++ b/pylabianca/stats.py
@@ -511,9 +511,8 @@ def _catch_common_percentile_errors(percentile, dist, tail):
     # the user wanted percentile of 5, and not 0.05)
     if percentile < 1:
         import warnings
-        per_text = f'{percentile:.2f} %'
-        warnings.warn('Percentile is very low ({per_text}). Remember that it '
-                      'is a percentile, not a fraction.')
+        warnings.warn(f'Percentile is very low ({percentile:.2f} %). Remember'
+                      ' that it is a percentile, not a fraction.')
 
     # additionally - if tail is 'both' (the default), check if the distribution
     # indeed contain positive and negative values - if not, warn the user

--- a/pylabianca/test/test_stats.py
+++ b/pylabianca/test/test_stats.py
@@ -132,69 +132,47 @@ def test_find_percentile_threshold():
 
 def test_cluster_based_test_return_clusters_object():
     from borsar.cluster.obj import Clusters
+    from pylabianca.testing import gen_random_xarr
 
     n_trials, n_cells, n_times = 40, 35, 60
-    times = np.linspace(-0.5, 1.5, num=n_times)
+    arr = gen_random_xarr(n_cells, n_trials, n_times,
+                        trial_condition_levels=[1, 2])
 
-    data = np.random.randn(n_trials, n_cells, n_times)
-    conditions = np.array([1] * (n_trials // 2) + [2] * (n_trials // 2))
-    np.random.shuffle(conditions)
-
-    effect_cond_mask = conditions == 1
-    data[effect_cond_mask, 1:4, 20:35] += 1.0
-
-    arr = xr.DataArray(
-        data, dims=['trial', 'cell', 'time'],
-        coords={'time': times, 'cond': ('trial', conditions)}
-    )
+    effect_cond_mask = arr.coords['cond'] == 1
+    has_eff = np.random.rand(n_cells) < 0.7
+    idx = np.ix_(has_eff, effect_cond_mask, np.arange(20, 35))
+    arr.data[idx] += 0.2
 
     np.random.seed(12)
+    args = dict(compare='cond', n_permutations=100, progress=False)
     with pytest.warns(FutureWarning, match='will change in the next version'):
-        stat, clusters, pval = pln.stats.cluster_based_test(
-            arr, compare='cond', n_permutations=100, progress=False)
+        stat, clusters, pval = pln.stats.cluster_based_test( arr, **args)
 
     np.random.seed(12)
-    clst = pln.stats.cluster_based_test(
-        arr, compare='cond', n_permutations=100, progress=False,
-        return_clusters=True)
+    clst = pln.stats.cluster_based_test(arr, return_clusters=True, **args)
 
     assert isinstance(clst, Clusters)
     assert clst.dimnames == ['cell', 'time']
-    np.testing.assert_array_equal(clst.dimcoords[0], cells)
-    np.testing.assert_array_equal(clst.dimcoords[1], times)
-
+    np.testing.assert_array_equal(clst.dimcoords[0], arr.cell.values)
+    np.testing.assert_array_equal(clst.dimcoords[1], arr.time.values)
     np.testing.assert_allclose(clst.stat, stat)
-    np.testing.assert_array_equal(clst.clusters, clusters)
-    np.testing.assert_array_equal(clst.pvals, pval)
+
+    # the order of clusters may be different
+    # so we compare the number of cluster members (across time) per cell
+    n_memb_clst = clst.clusters.any(axis=0).sum(axis=-1)
+    n_memb_arr = np.array(clusters).any(axis=0).sum(axis=-1)
+    np.testing.assert_array_equal(n_memb_clst, n_memb_arr)
+
+    assert (clst.pvals == pval).all()
 
     # make sure this also works after aggregation:
     agg = pln.aggregate(arr, groupby='cond')
-    clst = pln.stats.cluster_based_test(
-        agg, compare='cond', paired=True, n_permutations=100, progress=False,
-        return_clusters=True)
+    args['return_clusters'], args['paired'] = True, True
+    clst = pln.stats.cluster_based_test(agg, **args)
+    assert len(clst.dimnames) == 1
+    assert clst.dimnames[0] == 'time'
 
-
-def test_infer_cluster_dimnames_coords_respects_compare_dim():
-    n_cells, n_trials, n_times = 4, 20, 11
-    cells = np.array(['c1', 'c2', 'c3', 'c4'])
-    times = np.linspace(-0.1, 0.4, n_times)
-    cond = np.array([0] * (n_trials // 2) + [1] * (n_trials // 2))
-
-    frate = xr.DataArray(
-        np.random.randn(n_cells, n_trials, n_times),
-        dims=['cell', 'trial', 'time'],
-        coords={'cell': cells, 'time': times, 'cond': ('trial', cond),
-                'region': ('cell', ['A', 'B', 'A', 'C'])}
-    )
-
-    dimnames, dimcoords = pln.stats._infer_cluster_coords(frate, 'cond')
-
-    assert dimnames == ['cell', 'time']
-    np.testing.assert_array_equal(dimcoords[0], cells)
-    np.testing.assert_array_equal(dimcoords[1], times)
-
-    # make sure an error is raised
-    frate = frate.drop_vars('cond')
-    msg = 'Could not find the reduced dimension'
-    with pytest.raises(RuntimeError, match=msg):
-        dimnames, dimcoords = pln.stats._infer_cluster_coords(frate, 'cond')
+    agg = pln.aggregate(arr.transpose('trial', 'cell', 'time'), groupby='cond')
+    clst = pln.stats.cluster_based_test(agg, **args)
+    assert len(clst.dimnames) == 1
+    assert clst.dimnames[0] == 'time'

--- a/pylabianca/test/test_stats.py
+++ b/pylabianca/test/test_stats.py
@@ -135,7 +135,6 @@ def test_cluster_based_test_return_clusters_object():
 
     n_trials, n_cells, n_times = 40, 35, 60
     times = np.linspace(-0.5, 1.5, num=n_times)
-    cells = np.array(['cell_a', 'cell_b', 'cell_c', 'cell_d', 'cell_e'])
 
     data = np.random.randn(n_trials, n_cells, n_times)
     conditions = np.array([1] * (n_trials // 2) + [2] * (n_trials // 2))
@@ -146,7 +145,7 @@ def test_cluster_based_test_return_clusters_object():
 
     arr = xr.DataArray(
         data, dims=['trial', 'cell', 'time'],
-        coords={'time': times, 'cell': cells, 'cond': ('trial', conditions)}
+        coords={'time': times, 'cond': ('trial', conditions)}
     )
 
     np.random.seed(12)

--- a/pylabianca/test/test_stats.py
+++ b/pylabianca/test/test_stats.py
@@ -189,6 +189,6 @@ def test_cluster_based_test_return_clusters_object():
 
     # test raising error when compare coord is not found
     args['compare'] = 'nothing'
-    match = f'``compare`` \("nothing"\) was not found'
+    match = '``compare`` \("nothing"\) was not found'
     with pytest.raises(ValueError, match=match):
         clst = pln.stats.cluster_based_test(arr, **args)

--- a/pylabianca/test/test_stats.py
+++ b/pylabianca/test/test_stats.py
@@ -133,7 +133,7 @@ def test_find_percentile_threshold():
 def test_cluster_based_test_return_clusters_object():
     from borsar.cluster.obj import Clusters
 
-    n_trials, n_cells, n_times = 40, 5, 60
+    n_trials, n_cells, n_times = 40, 35, 60
     times = np.linspace(-0.5, 1.5, num=n_times)
     cells = np.array(['cell_a', 'cell_b', 'cell_c', 'cell_d', 'cell_e'])
 
@@ -167,6 +167,12 @@ def test_cluster_based_test_return_clusters_object():
     np.testing.assert_allclose(clst.stat, stat)
     np.testing.assert_array_equal(clst.clusters, clusters)
     np.testing.assert_array_equal(clst.pvals, pval)
+
+    # make sure this also works after aggregation:
+    agg = pln.aggregate(arr, groupby='cond')
+    clst = pln.stats.cluster_based_test(
+        agg, compare='cond', paired=True, n_permutations=100, progress=False,
+        return_clusters=True)
 
 
 def test_infer_cluster_dimnames_coords_respects_compare_dim():

--- a/pylabianca/test/test_stats.py
+++ b/pylabianca/test/test_stats.py
@@ -157,7 +157,9 @@ def test_cluster_based_test_return_clusters_object():
     np.testing.assert_array_equal(clst.dimcoords[1], arr.time.values)
     np.testing.assert_allclose(clst.stat, stat)
 
-    # the order of clusters may be different
+    # the order of clusters may be different (at least the test failed here,
+    # the order may be different due to sorting [or re-sorting?], when there
+    # are multiple clusters with identical p value)
     # so we compare the number of cluster members (across time) per cell
     n_memb_clst = clst.clusters.any(axis=0).sum(axis=-1)
     n_memb_arr = np.array(clusters).any(axis=0).sum(axis=-1)
@@ -176,3 +178,9 @@ def test_cluster_based_test_return_clusters_object():
     clst = pln.stats.cluster_based_test(agg, **args)
     assert len(clst.dimnames) == 1
     assert clst.dimnames[0] == 'time'
+
+    # test raising error when compare coord is not found
+    args['compare'] = 'nothing'
+    match = f'``compare`` \("nothing"\) was not found'
+    with pytest.raises(ValueError, match=match):
+        clst = pln.stats.cluster_based_test(arr, **args)

--- a/pylabianca/test/test_stats.py
+++ b/pylabianca/test/test_stats.py
@@ -157,6 +157,13 @@ def test_cluster_based_test_return_clusters_object():
     np.testing.assert_array_equal(clst.dimcoords[1], arr.time.values)
     np.testing.assert_allclose(clst.stat, stat)
 
+    # make sure the configuration is stored in .description
+    assert clst.description['n_permutations'] == 100
+    assert clst.description['compare'] == 'cond'
+    assert clst.description['levels'] == [1, 2]
+    assert clst.description['tail'] == 'both'
+    assert not clst.description['paired']
+
     # the order of clusters may be different (at least the test failed here,
     # the order may be different due to sorting [or re-sorting?], when there
     # are multiple clusters with identical p value)
@@ -169,7 +176,7 @@ def test_cluster_based_test_return_clusters_object():
 
     # make sure this also works after aggregation:
     agg = pln.aggregate(arr, groupby='cond')
-    args['return_clusters'], args['paired'] = True, True
+    args['return_clusters'] = True
     clst = pln.stats.cluster_based_test(agg, **args)
     assert len(clst.dimnames) == 1
     assert clst.dimnames[0] == 'time'
@@ -178,6 +185,7 @@ def test_cluster_based_test_return_clusters_object():
     clst = pln.stats.cluster_based_test(agg, **args)
     assert len(clst.dimnames) == 1
     assert clst.dimnames[0] == 'time'
+    assert clst.description['paired']
 
     # test raising error when compare coord is not found
     args['compare'] = 'nothing'

--- a/pylabianca/test/test_viz.py
+++ b/pylabianca/test/test_viz.py
@@ -358,16 +358,6 @@ def test_add_highlights():
     assert checks[0].sum() == 2
     assert checks[1].sum() == 2
 
-    # test with clusters of shape (1, n)
-    clusters = [c[None, :] for c in clusters]
-    ax = pln.viz.plot_shaded(fr.isel(cell=0))
-    pln.viz.add_highlights(fr, clusters, pvals)
-
-    ranges = ((0.45, 0.7),)
-    checks = compare_box_ranges(ax, ranges)
-    assert len(checks) == 1
-    assert checks[0].sum() == 2
-
 
 def test_plot_shaded_col_row_facets():
     """Test col and row faceting in plot_shaded."""

--- a/pylabianca/viz.py
+++ b/pylabianca/viz.py
@@ -922,9 +922,6 @@ def add_highlights(arr, clusters, pvals, p_threshold=0.05, ax=None,
         sig_idx = np.where(pvals_significant)[0]
         sig_clusters = [clusters[ix] for ix in sig_idx]
 
-        if sig_clusters[0].ndim > 1:
-            sig_clusters = [np.ravel(c) for c in sig_clusters]
-
         highlight(
             x_coords, sig_clusters, ax=ax,
             bottom_bar=True, bottom_extend=bottom_extend

--- a/whats_new.md
+++ b/whats_new.md
@@ -33,7 +33,10 @@
 * ENH: added `pylabianca.selectivity.compute_selectivity_multisession()` to compute selectivity on a multisession dictionary (session name -> xarray). The output is an xarray.Dataset with concatenated session selectivity results (the order of the sessions in the output xarray.Dataset is the same as in the input dictionary).
 * ENH: added `pylabianca.stats.find_percentile_threshold()` used to calculate significance threshold for given statistic based on percentile of the permutation distribution.
 * ENH: `pylabianca.selectivity.compute_selectivity_continuous()` now can be also run with `n_perm=0`, returning only the selectivity statistics, without the permutation distribution or permutation-based threshold. Also `pylabianca.stats.permutation_test()` can now be run with `n_perm=0`, returning only the statistic values without the permutation distribution or permutation-based threshold.
-* ENH: `pylabianca.cluster_based_test()` can now return `borsar.Clusters` object instead of ``(stat, clusters, pval)`` tuple. This behavior is optional and can be controlled by setting `return_clusters=True` (defaults to False but will change to True in the next version).
+* ENH: `pylabianca.stats.cluster_based_test()` can now return `borsar.Clusters` object instead of ``(stat, clusters, pval)`` tuple. This behavior is optional and can be controlled by setting `return_clusters=True` (defaults to False but will change to True in the next version).
+The returned Clusters object retains the number of perumtations, compared condition and its levels in the `description` dictionary
+ENH: `pylabianca.stats.cluster_based_test()` now infers the statistical test to perform (paired vs unpaired) from the DataArray structure. This behavior is the new default (but can be overriden by seeting the `paired` argument)
+ENH: `pylabianca.stats.cluster_based_test()` no longer expects the observations dimention (`compare`) to be the first one in the passed DataArray when performing an unpaired (independent) test.
 * ENH: `pylabianca.viz.plot_shaded()` now allows to facet by condition into rows and columns using `row` and `col` arguments
 * ENH: allow passing colors by name to `colors` in `pylabianca.viz.plot_shaded()`.
 
@@ -57,7 +60,7 @@
 * FIX: `pylabianca.utils._handle_cell_names()` (used internally in a few places) now works with NumPy >= 2.0.
 * FIX: `pylabianca.viz.plot_waveform()` (as well as `.plot_waveform()` methods of `Spikes` and `SpikeEpochs`) now produces a clearer error when no waveforms are present in the data.
 * FIX: fixed `pval_text=False` still giving p value text (but without text boxes) in `pylabianca.viz.add_highlights()`
-* FIX: using `pylabianca.stats.cluster_based_test()` would often give (1, n) shaped clusters and passing these to `pylabianca.viz.add_highlighs()` lead to errors. This has now been fixed - such clusters would be ravel()'ed into 1d representation.
+FIX: `pylabianca.stats.cluster_based_test()` no longer returns stats and clusters arrays being n_timepoints x 1 when performing a paired (repeated) test.
 * FIX: `pylabianca.io.read_spikes_neo()` started raising errors on new pandas version when reading fieldtrip example spike data. Newer pandas for some reason started to generate StringArray columns when converting the header to pandas dataframe (although the docs seem to suggest that StringArray is experimental), which lead to TypeError when creating the `pylabinaca.Spikes()` object. This is now fixed.
 * FIX: `pylabianca.viz.add_highlights()` now correctly uses 'time' dimension as x coordinate, even if it is not the last dimension in the DataArray
 * FIX: `pylabianca.analysis.aggregate()` now works with `xarray.DataArray` input to `zscore` (previously it would raise an error). When aggregating a dictionary of DataArrays `zscore` (if in the form of arrays) has to be a matching dictionary of DataArrays as well.


### PR DESCRIPTION
For within-cell setup for example it would give errors, because it didn't consider 2 dimensions are reduced (observations and the condition dimention). Also fixes the earlier issue of clusters being n_timepoints x 1.