### PR TITLE
Skip ZETA test if zetapy missing; use local EmptyProgressbar with close() in viz

### DIFF
--- a/pylabianca/test/test_zeta.py
+++ b/pylabianca/test/test_zeta.py
@@ -1,12 +1,18 @@
 # test ZETA test
 import time
+import importlib.util
 import numpy as np
 import pandas as pd
+import pytest
 from scipy.io import loadmat
 
 import pylabianca as pln
 
 
+@pytest.mark.skipif(
+    importlib.util.find_spec("zetapy") is None,
+    reason="requires optional dependency: zetapy",
+)
 def test_against_zetapy():
     from zetapy import zetatest2
 

--- a/pylabianca/viz.py
+++ b/pylabianca/viz.py
@@ -390,7 +390,6 @@ def check_modify_progressbar(pbar, total=None):
             from tqdm import tqdm
             pbar = tqdm(total=total)
         else:
-            from sarna.utils import EmptyProgressbar
             pbar = EmptyProgressbar(total=total)
     elif isinstance(pbar, str):
         if pbar == 'notebook':
@@ -417,6 +416,9 @@ class EmptyProgressbar(object):
         self.total = total
 
     def update(self, val):
+        pass
+
+    def close(self):
         pass
 
 


### PR DESCRIPTION
### Motivation
- Make the ZETA comparison test optional when the `zetapy` optional dependency is not installed so CI/local runs don't fail.
- Remove an implicit dependency on `sarna.utils.EmptyProgressbar` inside the visualization utility to reduce external coupling.
- Prevent potential resource/cleanup errors by adding a `close` method to the local empty progressbar implementation.

### Description
- Added `importlib.util` and `pytest` imports and decorated the ZETA test with `@pytest.mark.skipif(importlib.util.find_spec("zetapy") is None, reason="requires optional dependency: zetapy")` in `pylabianca/test/test_zeta.py` so the test is skipped when `zetapy` is unavailable.
- Replaced the in-branch import of `EmptyProgressbar` from `sarna.utils` with the module-local `EmptyProgressbar` class in `pylabianca/viz.py` to avoid requiring `sarna` at runtime.
- Implemented a no-op `close` method on the local `EmptyProgressbar` class in `pylabianca/viz.py` to match common progressbar APIs and avoid attribute errors.

### Testing
- Ran `pytest pylabianca/test/test_zeta.py` in an environment without `zetapy` and the test was skipped as expected.
- Performed a basic import smoke test of the visualization module by importing `pylabianca.viz` and checking that `EmptyProgressbar` exposes a `close` attribute, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d179991d848329af533b5c655648e8)