### PR TITLE
Return borsar.Clusters from cluster-based tests and add opt-in warning

### DIFF
--- a/pylabianca/stats.py
+++ b/pylabianca/stats.py
@@ -157,11 +157,7 @@ def cluster_based_test(frate, compare='image', cluster_entry_pval=0.05,
 
     if return_clusters is None:
         return_clusters = False
-        warnings.warn('The default behavior of returning (stats, clusters, '
-                      'pvals) tuple will change in the next version to '
-                      'returning one `borsar.Clusters` object. To retain the'
-                      ' old behavior use `return_clusters=False`.',
-                      FutureWarning)
+        _warn_return_clusters_change('(stats, clusters, pvals)')
 
     arrays, levels, dimnames, paired = _prepare_arrays(frate, compare, paired)
 
@@ -178,14 +174,13 @@ def cluster_based_test(frate, compare='image', cluster_entry_pval=0.05,
     if return_clusters:
         from borsar.cluster.obj import Clusters
         dimcoords = [frate.coords[dimname].values for dimname in dimnames]
-        desc = { 'compare': compare, 'levels': levels, 'paired': paired,
+        desc = {'compare': compare, 'levels': levels, 'paired': paired,
                 'tail': tail, 'n_permutations': n_permutations,
                 'n_stat_permutations': n_stat_permutations,
                 'cluster_entry_p_threshold': cluster_entry_pval}
-        return Clusters(
-            stat, clusters=clusters, pvals=pval,
-            dimnames=dimnames, dimcoords=dimcoords, description=desc
-        )
+        return Clusters(stat, clusters=clusters, pvals=pval,
+                        dimnames=dimnames, dimcoords=dimcoords,
+                        description=desc)
 
     return stat, clusters, pval
 
@@ -251,7 +246,8 @@ def _prepare_arrays(frate, compare, paired):
 # ENH: return borsar.Clusters object as output
 def cluster_based_test_from_permutations(data, perm_data, tail='both',
                                          adjacency=None, percentile=5,
-                                         threshold=None):
+                                         threshold=None,
+                                         return_clusters=None):
     '''Performs a cluster-based test from precalculated permutations.
 
     This function should get data ready for cluster-based permutation test
@@ -288,23 +284,31 @@ def cluster_based_test_from_permutations(data, perm_data, tail='both',
     threshold : float
         Threshold to use for clustering. If ``None`` then the threshold is
         calculated using the ``percentile`` parameter.
+    return_clusters : bool
+        Whether to return a ``borsar.Clusters`` object instead of a
+        ``(clusters, cluster_stats, cluster_pval)`` tuple.
 
     Returns
     -------
-    clusters : list of numpy.ndarray
-        List of cluster memberships.
+    clusters : list of numpy.ndarray | borsar.Clusters
+        List of cluster memberships. If ``return_clusters=True``, then a
+        ``borsar.Clusters`` object is returned instead.
     cluster_stats : numpy.ndarray
-        Cluster statistics.
+        Cluster statistics. Only returned if ``return_clusters=False``.
     cluster_pval : numpy.ndarray
-        Cluster p values.
+        Cluster p values. Only returned if ``return_clusters=False``.
     '''
     import xarray as xr
     import borsar
 
+    if return_clusters is None:
+        return_clusters = False
+        _warn_return_clusters_change('(clusters, cluster_stats, cluster_pval)')
+
     assert isinstance(data, xr.DataArray)
     assert isinstance(perm_data, xr.DataArray)
 
-    perm_dim_name, _ = _find_dim(perm_data)
+    perm_dim_name, perm_dim_idx = _find_dim(perm_data)
 
     if threshold is None:
         thresholds = find_percentile_threshold(
@@ -357,7 +361,28 @@ def cluster_based_test_from_permutations(data, perm_data, tail='both',
         # and one for neg clusters) so we have to correct...
         cluster_pval = np.minimum(cluster_pval * 2, 1)
 
+    if return_clusters:
+        from borsar.cluster.obj import Clusters
+        dimnames = list(data.dims)
+        dimcoords = [data.coords[dimname].values for dimname in dimnames]
+        desc = {
+            'tail': tail, 'percentile': percentile, 'threshold': threshold,
+            'adjacency': adjacency,
+            'n_permutations': perm_data.shape[perm_dim_idx]
+        }
+        return Clusters(data.values, clusters=clusters, pvals=cluster_pval,
+                        dimnames=dimnames, dimcoords=dimcoords,
+                        description=desc)
+
     return clusters, cluster_stats, cluster_pval
+
+
+def _warn_return_clusters_change(returned_tuple):
+    warnings.warn(
+        f'The default behavior of returning {returned_tuple} tuple will '
+        'change in the next version to returning one `borsar.Clusters` '
+        'object. To retain the old behavior use `return_clusters=False`.',
+        FutureWarning)
 
 
 # CONSIDER: move the xarray "clothing" function somewhere to utils

--- a/pylabianca/test/test_stats.py
+++ b/pylabianca/test/test_stats.py
@@ -46,7 +46,7 @@ def test_permutation_test_n_perm_0():
 
 
 def test_cluster_based_test_from_permutations():
-    from borsar.cluster.obj import Clusters
+    from borsar import Clusters
 
     n_trials, n_times = 50, 100
     times = np.linspace(-0.5, 1.5, num=n_times)
@@ -105,19 +105,19 @@ def test_cluster_based_test_from_permutations():
     assert (clst2[0] == clst[0]).mean() >= 0.9
 
     # test Clusters output with metadata
-    clst_obj = pln.stats.cluster_based_test_from_permutations(
+    clst = pln.stats.cluster_based_test_from_permutations(
         stat, stat_perm, return_clusters=True, tail='both')
-    assert isinstance(clst_obj, Clusters)
-    assert clst_obj.dimnames == ['time']
-    np.testing.assert_array_equal(clst_obj.dimcoords[0], times)
-    np.testing.assert_array_equal(clst_obj.stat, stat.values)
-    np.testing.assert_array_equal(clst_obj.pvals, pval2_unsorted)
+    assert isinstance(clst, Clusters)
+    assert clst.dimnames == ['time']
+    np.testing.assert_array_equal(clst.dimcoords[0], times)
+    np.testing.assert_array_equal(clst.stat, stat.values)
+    np.testing.assert_array_equal(clst.pvals, pval2_unsorted)
 
-    assert clst_obj.description['tail'] == 'both'
-    assert clst_obj.description['percentile'] == 5
-    assert clst_obj.description['threshold'] is None
-    assert clst_obj.description['n_permutations'] == n_permutations
-    assert 'perm_dim' not in clst_obj.description
+    assert clst.description['tail'] == 'both'
+    assert clst.description['percentile'] == 5
+    assert clst.description['threshold'] is None
+    assert clst.description['n_permutations'] == n_permutations
+    assert 'perm_dim' not in clst.description
 
 
 def test_find_percentile_threshold():
@@ -150,7 +150,7 @@ def test_find_percentile_threshold():
 
 
 def test_cluster_based_test_return_clusters_object():
-    from borsar.cluster.obj import Clusters
+    from borsar import Clusters
     from pylabianca.testing import gen_random_xarr
 
     n_trials, n_cells, n_times = 40, 35, 60

--- a/pylabianca/test/test_stats.py
+++ b/pylabianca/test/test_stats.py
@@ -46,6 +46,8 @@ def test_permutation_test_n_perm_0():
 
 
 def test_cluster_based_test_from_permutations():
+    from borsar.cluster.obj import Clusters
+
     n_trials, n_times = 50, 100
     times = np.linspace(-0.5, 1.5, num=n_times)
     data = np.random.rand(n_trials, n_times)
@@ -90,8 +92,10 @@ def test_cluster_based_test_from_permutations():
                              coords={'time': times})
 
     # compute test from permuted stats
-    clst2, _, pval2 = pln.stats.cluster_based_test_from_permutations(
-        stat, stat_perm)
+    with pytest.warns(FutureWarning, match='will change in the next version'):
+        clst2, _, pval2 = pln.stats.cluster_based_test_from_permutations(
+            stat, stat_perm)
+    pval2_unsorted = pval2.copy()
 
     # sort for comparison
     srt_idx = pval2.argsort()
@@ -99,6 +103,21 @@ def test_cluster_based_test_from_permutations():
     clst2 = [clst2[idx] for idx in srt_idx]
 
     assert (clst2[0] == clst[0]).mean() >= 0.9
+
+    # test Clusters output with metadata
+    clst_obj = pln.stats.cluster_based_test_from_permutations(
+        stat, stat_perm, return_clusters=True, tail='both')
+    assert isinstance(clst_obj, Clusters)
+    assert clst_obj.dimnames == ['time']
+    np.testing.assert_array_equal(clst_obj.dimcoords[0], times)
+    np.testing.assert_array_equal(clst_obj.stat, stat.values)
+    np.testing.assert_array_equal(clst_obj.pvals, pval2_unsorted)
+
+    assert clst_obj.description['tail'] == 'both'
+    assert clst_obj.description['percentile'] == 5
+    assert clst_obj.description['threshold'] is None
+    assert clst_obj.description['n_permutations'] == n_permutations
+    assert 'perm_dim' not in clst_obj.description
 
 
 def test_find_percentile_threshold():


### PR DESCRIPTION
### Motivation
- Provide an option to return a single `borsar.Clusters` object from cluster-based test helpers instead of the existing `(clusters, stats, pvals)` tuple and warn users about the upcoming default change.
- Attach metadata (dim names, coords and description) to cluster results to make downstream analysis easier.

### Description
- Added an optional `return_clusters` parameter to `cluster_based_test_from_permutations` and threaded the existing `return_clusters` handling in `cluster_based_test` to use a helper `_warn_return_clusters_change` that emits a `FutureWarning` when `return_clusters` is `None`.
- When `return_clusters=True`, both `cluster_based_test` and `cluster_based_test_from_permutations` now construct and return a `borsar.cluster.obj.Clusters` object with `stat`, `clusters`, `pvals`, `dimnames`, `dimcoords` and a `description` dict containing test parameters.
- Added the `_warn_return_clusters_change` helper to centralize the warning message and adjusted some minor formatting in the `Clusters` constructor calls.
- Updated `pylabianca/test/test_stats.py` to expect the `FutureWarning` for the legacy tuple return and added tests that assert the returned `Clusters` object, its `dimnames`, `dimcoords`, `stat`, `pvals`, and `description` fields.

### Testing
- Ran the updated unit tests in `pylabianca/test/test_stats.py`, including `test_cluster_based_test_from_permutations` and `test_find_percentile_threshold`, which passed locally.
- Verified that a `FutureWarning` is emitted when calling `cluster_based_test_from_permutations` without `return_clusters` and that `return_clusters=True` returns a valid `borsar.Clusters` object with expected metadata.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d17a904ffc83298edbaccaa41baae3)