### PR TITLE
fix for xarray_to_dict when no cell dim/coord in data

### DIFF
--- a/pylabianca/analysis.py
+++ b/pylabianca/analysis.py
@@ -1024,7 +1024,7 @@ def xarray_to_dict(xarr, ses_coord='sub', reduce_coords=True,
     '''Convert multi-session xarray to dictionary of session -> xarray pairs.
 
     Note, that it is assumed that each session is a contiguous block in the
-    xarray along the cell dimension.
+    xarray along the dimension of the session coordinate.
 
     Parameters
     ----------

--- a/pylabianca/analysis.py
+++ b/pylabianca/analysis.py
@@ -1061,20 +1061,23 @@ def xarray_to_dict(xarr, ses_coord='sub', reduce_coords=True,
                         'xarray.Dataset.')
 
     _check_ses_coord(xarr, ses_coord, ses_name)
-    sessions, ses_idx = np.unique(xarr.coords[ses_coord].values, return_index=True)
+    sessions_all = xarr.coords[ses_coord]
+    assert len(sessions_all.dims) == 1
+    obs_dim = sessions_all.dims[0]
+    sessions, ses_idx = np.unique(sessions_all.values, return_index=True)
 
     sort_idx = np.argsort(ses_idx)
     sessions = sessions[sort_idx]
     ses_idx = ses_idx[sort_idx]
-    ses_idx = np.append(ses_idx, xarr.cell.shape[0])
+    ses_idx = np.append(ses_idx, xarr.coords[obs_dim].shape[0])
 
     for idx, ses in enumerate(sessions):
-        arr = xarr.isel(cell=slice(ses_idx[idx], ses_idx[idx + 1]))
+        arr = xarr.isel({obs_dim: slice(ses_idx[idx], ses_idx[idx + 1])})
         if reduce_coords:
             new_coords = dict()
             drop_coords = list()
-            if 'cell' in arr.coords and 'trial' in arr.coords:
-                nested_coords = find_nested_dims(arr, ('cell', 'trial'))
+            if 'trial' in arr.coords:
+                nested_coords = find_nested_dims(arr, (obs_dim, 'trial'))
             else:
                 nested_coords = list()
 

--- a/pylabianca/stats.py
+++ b/pylabianca/stats.py
@@ -210,7 +210,8 @@ def _prepare_arrays(frate, compare, paired):
     if compare in frate.dims:
         drop_dims.append(compare)
         dim_idx = frate.dims.index(compare)
-        arrays = [np.squeeze(arr, axis=dim_idx) for arr in arrays]
+        if arrays[0].ndim == frate.ndim:
+            arrays = [np.squeeze(arr, axis=dim_idx) for arr in arrays]
 
         # first dimension (observations) should be reduced
         # TODO: auto-detect observation dimension and make sure it is first

--- a/pylabianca/test/test_analysis.py
+++ b/pylabianca/test/test_analysis.py
@@ -214,6 +214,34 @@ def test_xarr_dct_conversion():
     xarr_2 = pln.dict_to_xarray(x_dct2)
     assert (xarr == xarr_2).all().item()
 
+    # session information can live on a dimension other than cell
+    sessions = np.array(['beh-A01', 'beh-A02'])
+    choices = np.array([
+        ['left', 'right', 'left', 'right'],
+        ['right', 'right', 'left', 'left'],
+    ])
+    arr = xr.DataArray(
+        np.arange(sessions.size * 4).reshape(-1, 4),
+        dims=['session', 'trial'],
+        coords={
+            'trial': np.arange(4),
+            'sub': ('session', sessions),
+            'choice': (('session', 'trial'), choices),
+        },
+        name='reaction_time',
+    )
+    assert 'cell' not in arr.dims
+
+    arr_dct = pln.xarray_to_dict(arr)
+    assert list(arr_dct) == list(sessions)
+    for idx, ses in enumerate(sessions):
+        ses_arr = arr_dct[ses]
+        assert ses_arr.dims == ('session', 'trial')
+        assert ses_arr.shape == (1, 4)
+        assert ses_arr.coords['sub'].item() == ses
+        assert ses_arr.coords['choice'].dims == ('trial',)
+        assert (ses_arr.coords['choice'].values == choices[idx]).all()
+
     # for some reason performing a query will not work without
     # assigning a name to the DataArray
     # we test this here to be warned when this behavior is changed in xarray

--- a/whats_new.md
+++ b/whats_new.md
@@ -22,7 +22,8 @@
 * ENH: `SpikeEpochs.spike_rate()` now has a `count` argument to return spike counts without normalizing by window length.
 * ENH: `Spikes.epoch()` with `backend='numba'` has been further sped up, it is now 30-40 times faster than numpy
 * ENH: `pylabianca.analysis.spike_centered_windows()` (previously `pylabianca.utils.spike_centered_windows()`) has been sped up twofold.
-* ENH: `pylabianca.analysis.xarray_to_dict()` has been sped up considerably. It relies on sessions being concatenated along the cell dimension (so each session being a contiguous block of cells).
+* ENH: `pylabianca.analysis.xarray_to_dict()` has been sped up considerably. It relies on sessions being concatenated along the dimension of the session coordinate (so each session is a contiguous block of observations, usually cells).
+* ENH: `pylabianca.analysis.xarray_to_dict()` can now split xarrays whose session information is defined along any single observation dimension, so the dimension does not have to be named `cell`.
 * ENH: `pylabianca.analysis.aggregate()` receives a `backend` argument that can be set to `'numba'` for per-cell execution (`per_cell=True`) speeding it up considerably.
 * ENH: add `pylabianca.utils._inherit_from_xarray()` to allow inheriting metadata (cell or trial-level additional information) from xarray DataArray to new xarray DataArray.
 * ENH: `pylabianca.analysis.dict_to_xarray()` now allows to pass dictionary of `xarray.Dataset` as input.


### PR DESCRIPTION
Would be useful to make as many function not rely on specific dimension names (or provide an option to change the defaults), so that the functions can be better reused.
This is a stub, still needs tests etc.